### PR TITLE
feat: add SwimmerCost environment

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
 ]
 autoapi_dirs = ["../../stable_gym"]
 myst_heading_anchors = 2  # Add anchors to headings.
+myst_enable_extensions = ["dollarmath", "html_image"]
 
 # Extensions settings.
 autodoc_member_order = "bysource"

--- a/docs/source/envs/envs.rst
+++ b/docs/source/envs/envs.rst
@@ -29,6 +29,16 @@ Environments for classical control theory problems.
     ./classic_control/ex3_ekf.rst
     ./classic_control/cartpole_cost.rst
 
+Mujoco environments
+-------------------
+
+Environments that are based on the MuJoCo physics engine.
+
+.. toctree::
+    :maxdepth: 1
+
+    ./mujoco/swimmer_cost.rst
+
 Robotics environment
 --------------------
 

--- a/docs/source/envs/envs.rst
+++ b/docs/source/envs/envs.rst
@@ -21,7 +21,10 @@ Gym environments that are based on Biological systems.
 Classic control environments
 ----------------------------
 
-Environments that are based on the `classical control gymnasium environments`_.
+Environments that are based on classical control problems or `classical control`_ 
+environments found in the :gymnasium:`gymnasium <>` library.
+
+.. _`classical control`: https://gymnasium.farama.org/environments/classic_control
 
 .. toctree::
     :maxdepth: 1
@@ -29,19 +32,21 @@ Environments that are based on the `classical control gymnasium environments`_.
     ./classic_control/ex3_ekf.rst
     ./classic_control/cartpole_cost.rst
 
+
 .. _`classical control gymnasium environments`: https://gymnasium.farama.org/environments/classic_control
 
 Mujoco environments
 -------------------
 
-Environments that are based on the `mujoco gymnasium environments`_.
+Environments that are based on the on `Mujoco`_ or `Mujoco gymnasium`_ environments.
 
 .. toctree::
     :maxdepth: 1
 
     ./mujoco/swimmer_cost.rst
 
-.. _`mujoco gymnasium environments`: https://gymnasium.farama.org/environments/mujoco
+.. _`Mujoco`: https://mujoco.org/
+.. _`mujoco gymnasium`: https://gymnasium.farama.org/environments/mujoco
 
 Robotics environment
 --------------------

--- a/docs/source/envs/envs.rst
+++ b/docs/source/envs/envs.rst
@@ -21,7 +21,7 @@ Gym environments that are based on Biological systems.
 Classic control environments
 ----------------------------
 
-Environments for classical control theory problems.
+Environments that are based on the `classical control gymnasium environments`_.
 
 .. toctree::
     :maxdepth: 1
@@ -29,15 +29,19 @@ Environments for classical control theory problems.
     ./classic_control/ex3_ekf.rst
     ./classic_control/cartpole_cost.rst
 
+.. _`classical control gymnasium environments`: https://gymnasium.farama.org/environments/classic_control
+
 Mujoco environments
 -------------------
 
-Environments that are based on the MuJoCo physics engine.
+Environments that are based on the `mujoco gymnasium environments`_.
 
 .. toctree::
     :maxdepth: 1
 
     ./mujoco/swimmer_cost.rst
+
+.. _`mujoco gymnasium environments`: https://gymnasium.farama.org/environments/mujoco
 
 Robotics environment
 --------------------

--- a/docs/source/envs/mujoco/swimmer_cost.rst
+++ b/docs/source/envs/mujoco/swimmer_cost.rst
@@ -1,0 +1,2 @@
+.. include:: ../../../../stable_gym/envs/mujoco/swimmer_cost/README.md
+    :parser: myst_parser.sphinx_

--- a/examples/use_stable_gym.py
+++ b/examples/use_stable_gym.py
@@ -6,7 +6,7 @@ import stable_gym  # noqa: F401
 ENV_NAME = "Oscillator-v1"
 # ENV_NAME = "Ex3EKF-v1"
 # ENV_NAME = "CartPoleCost-v1"
-ENV_NAME = "Swimmer-v4"
+# ENV_NAME = "SwimmerCost-v1"
 
 if __name__ == "__main__":
     env = gym.make(ENV_NAME, render_mode="human")

--- a/examples/use_stable_gym.py
+++ b/examples/use_stable_gym.py
@@ -6,6 +6,7 @@ import stable_gym  # noqa: F401
 ENV_NAME = "Oscillator-v1"
 # ENV_NAME = "Ex3EKF-v1"
 # ENV_NAME = "CartPoleCost-v1"
+ENV_NAME = "Swimmer-v4"
 
 if __name__ == "__main__":
     env = gym.make(ENV_NAME, render_mode="human")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "gymnasium>=0.28.1",
     "gymnasium[classic_control]>=0.28.1",
+    "gymnasium[mujoco]>=0.28.1",
     "matplotlib>=3.7.1",
     "iteration_utilities>=0.11.0"
 ]

--- a/stable_gym/__init__.py
+++ b/stable_gym/__init__.py
@@ -3,10 +3,10 @@ import gymnasium as gym
 from gymnasium.envs.registration import register
 
 # Make module version available.
-from .version import __version__
-from .version import __version_tuple__
+from .version import __version__, __version_tuple__
 
 # Available environments.
+# TODO: Update reward thresholds.
 ENVS = {
     "Oscillator-v1": {
         "module": "stable_gym.envs.biological.oscillator.oscillator:Oscillator",
@@ -25,6 +25,11 @@ ENVS = {
     },
     "CartPoleCost-v1": {
         "module": "stable_gym.envs.classic_control.cartpole_cost.cartpole_cost:CartPoleCost",
+        "max_step": 250,
+        "reward_threshold": 300,
+    },
+    "SwimmerCost-v1": {
+        "module": "stable_gym.envs.mujoco.swimmer_cost.swimmer_cost:SwimmerCost",
         "max_step": 250,
         "reward_threshold": 300,
     },

--- a/stable_gym/envs/biological/oscillator/README.md
+++ b/stable_gym/envs/biological/oscillator/README.md
@@ -31,9 +31,9 @@ The agent's goal in the oscillator environment is to act in such a way that one 
 
 The Oscillator environment uses the absolute difference between the reference and the state of interest as the cost function:
 
-```python
-cost = np.square(p1 - r1)
-```
+$$
+cost = (p\_1 - r\_1)^2
+$$
 
 ## Environment step return
 

--- a/stable_gym/envs/biological/oscillator/README.md
+++ b/stable_gym/envs/biological/oscillator/README.md
@@ -32,7 +32,7 @@ The agent's goal in the oscillator environment is to act in such a way that one 
 The Oscillator environment uses the absolute difference between the reference and the state of interest as the cost function:
 
 $$
-cost = (p\_1 - r\_1)^2
+cost = (p_1 - r_1)^2
 $$
 
 ## Environment step return

--- a/stable_gym/envs/biological/oscillator/oscillator.py
+++ b/stable_gym/envs/biological/oscillator/oscillator.py
@@ -232,13 +232,13 @@ class Oscillator(gym.Env, OscillatorDisturber):
         Returns:
             (tuple): tuple containing:
 
-                - obs (:obj:`numpy.ndarray`): The current state
-                - cost (:obj:`numpy.float64`): The current cost.
-                - terminated (:obj:`bool`): Whether the episode was done.
+                - obs (:obj:`np.ndarray`): Environment observation.
+                - cost (:obj:`float`): Cost of the action.
+                - terminated (:obj`bool`): Whether the episode is terminated.
                 - truncated (:obj:`bool`): Whether the episode was truncated. This value
                     is set by wrappers when for example a time limit is reached or the
                     agent goes out of bounds.
-                - info_dict (:obj:`dict`): Dictionary with additional information.
+                - info (:obj`dict`): Additional information about the environment.
         """
         # Clip action if needed.
         if self._clip_action:

--- a/stable_gym/envs/classic_control/__init__.py
+++ b/stable_gym/envs/classic_control/__init__.py
@@ -1,7 +1,7 @@
-"""Stable Gym gymnasium environments that are based on
-`classical control gymnasium environments`_.
+"""Stable Gym gymnasium environments based on classical control problems or
+`classical control`_ environments found in the :gymnasium:`gymnasium <>` library.
 
-.. _`classical control gymnasium environments`: https://gymnasium.farama.org/environments/classic_control
+.. _`classical control`: https://gymnasium.farama.org/environments/classic_control
 """  # noqa: E501
 from stable_gym.envs.classic_control.cartpole_cost.cartpole_cost import CartPoleCost
 from stable_gym.envs.classic_control.ex3_ekf.ex3_ekf import Ex3EKF

--- a/stable_gym/envs/classic_control/__init__.py
+++ b/stable_gym/envs/classic_control/__init__.py
@@ -1,5 +1,7 @@
-"""Stable Gym gymnasium environments that are based on classical control  theory
-problems.
-"""
+"""Stable Gym gymnasium environments that are based on
+`classical control gymnasium environments`_.
+
+.. _`classical control gymnasium environments`: https://gymnasium.farama.org/environments/classic_control
+"""  # noqa: E501
 from stable_gym.envs.classic_control.cartpole_cost.cartpole_cost import CartPoleCost
 from stable_gym.envs.classic_control.ex3_ekf.ex3_ekf import Ex3EKF

--- a/stable_gym/envs/classic_control/cartpole_cost/README.md
+++ b/stable_gym/envs/classic_control/cartpole_cost/README.md
@@ -1,6 +1,8 @@
 # CartPoleCost gymnasium environment
 
-![cart\_pole](https://github.com/rickstaa/stable-gym/assets/17570430/eb3d4f34-1429-4597-a51f-16aea0e7def2)
+<div align="center">
+    <img src="https://github.com/rickstaa/stable-gym/assets/17570430/eb3d4f34-1429-4597-a51f-16aea0e7def2" alt="cartpole" width="400px">
+</div>
 
 <!--alex ignore joint-->
 
@@ -66,7 +68,7 @@ The cost function of this environment is designed in such a way that it tries to
 *   A stabilisation task. In this task, the agent attempts to stabilize a given state (e.g. keep the pole angle and or cart position zero)
 *   A reference tracking task. The agent tries to make a state track a given reference in this task.
 
-The exact definition of these tasks can be found in the environment `cost()` method.
+The exact definition of these tasks can be found in the environment's `stable_gym.envs.classical_control.cartpole_cost.cartpole_cost.CartPoleCost.cost` method.
 
 ## Environment step return
 

--- a/stable_gym/envs/classic_control/cartpole_cost/cartpole_cost.py
+++ b/stable_gym/envs/classic_control/cartpole_cost/cartpole_cost.py
@@ -33,15 +33,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         Stable Learning Control package (SLC). For more information see
         `the SLC documentation <https://rickstaa.dev/stable-learning-control/utils/tester.html#robustness-eval-utility>`_.
 
-    Description:
-        This environment was based on the cart-pole environment described by Barto,
-        Sutton, and Anderson in
-        `Neuronlike Adaptive Elements That Can Solve Difficult Learning Control Problem`_.
-        A pole is attached by an un-actuated joint to a cart, which moves along a
-        frictionless track. The pendulum is placed upright on the cart and the goal
-        is to balance the pole while optionally tracking a certain reference signal by
-        applying forces in the left and right direction on the cart.
-
     Source:
         This environment corresponds to the version that is included in the Farama
         Foundation gymnasium package. It is different from this version in the fact
@@ -389,13 +380,13 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         Returns:
             (tuple): tuple containing:
 
-                - obs (:obj:`numpy.ndarray`): The current state
-                - cost (:obj:`numpy.float64`): The current cost.
-                - terminated (:obj:`bool`): Whether the episode was done.
+                - obs (:obj:`np.ndarray`): Environment observation.
+                - cost (:obj:`float`): Cost of the action.
+                - terminated (:obj`bool`): Whether the episode is terminated.
                 - truncated (:obj:`bool`): Whether the episode was truncated. This value
                     is set by wrappers when for example a time limit is reached or the
                     agent goes out of bounds.
-                - info_dict (:obj:`dict`): Dictionary with additional information.
+                - info (:obj`dict`): Additional information about the environment.
         """
         # Clip action if needed.
         # NOTE: This is not done in the original environment.

--- a/stable_gym/envs/classic_control/ex3_ekf/ex3_ekf.py
+++ b/stable_gym/envs/classic_control/ex3_ekf/ex3_ekf.py
@@ -148,13 +148,13 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
         Returns:
             (tuple): tuple containing:
 
-                - obs (:obj:`numpy.ndarray`): The current state
-                - cost (:obj:`numpy.float64`): The current cost.
-                - terminated (:obj:`bool`): Whether the episode was done.
+                - obs (:obj:`np.ndarray`): Environment observation.
+                - cost (:obj:`float`): Cost of the action.
+                - terminated (:obj`bool`): Whether the episode is terminated.
                 - truncated (:obj:`bool`): Whether the episode was truncated. This value
                     is set by wrappers when for example a time limit is reached or the
                     agent goes out of bounds.
-                - info_dict (:obj:`dict`): Dictionary with additional information.
+                - info (:obj`dict`): Additional information about the environment.
         """
         # Clip action if needed.
         if self._clipped_action:

--- a/stable_gym/envs/classic_control/ex3_ekf/requirements.txt
+++ b/stable_gym/envs/classic_control/ex3_ekf/requirements.txt
@@ -1,2 +1,3 @@
 gymnasium==0.28.1
+gymnasium[classic_control]==0.28.1
 matplotlib==3.7.0

--- a/stable_gym/envs/mujoco/__init__.py
+++ b/stable_gym/envs/mujoco/__init__.py
@@ -1,0 +1,4 @@
+"""Stable Gym gymnasium environments that are based on `Mujoco gymnasium environments`_.
+
+.. _`Mujoco gymnasium environments`: https://gymnasium.farama.org/environments/mujoco
+"""

--- a/stable_gym/envs/mujoco/__init__.py
+++ b/stable_gym/envs/mujoco/__init__.py
@@ -1,4 +1,5 @@
-"""Stable Gym gymnasium environments that are based on `Mujoco gymnasium environments`_.
+"""Stable Gym gymnasium environments that are based on `Mujoco`_ or `Mujoco gymnasium`_ environments.
 
-.. _`Mujoco gymnasium environments`: https://gymnasium.farama.org/environments/mujoco
+.. _`Mujoco`: https://mujoco.org
+.. _`Mujoco gymnasium`: https://gymnasium.farama.org/environments/mujoco
 """

--- a/stable_gym/envs/mujoco/swimmer_cost/README.md
+++ b/stable_gym/envs/mujoco/swimmer_cost/README.md
@@ -1,0 +1,24 @@
+# SwimmerCost gymnasium environment
+
+<div align="center">
+    <img src="https://github.com/rickstaa/stable-gym/assets/17570430/dccd73b4-c97e-46ce-ba0d-4a1328c0aefe" alt="swimmer" width="200px">
+</div>
+</br>
+
+An actuated two-jointed swimmer. This environment corresponds to the [Swimmer-v2](https://gym.openai.com/envs/Swimmer-v2/) environment included in the OpenAI gym package. It is different in the fact that:
+
+*   The objective was changed to a speed-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the swimmer's forward speed and a reference value (error).
+
+The rest of the environment is the same as the original Swimmer environment. Below, the modified cost is described. For more information about the environment (e.g. observation space, action space, episode termination, etc.), please refer to the [gymnasium library](https://gymnasium.farama.org/environments/mujoco/swimmer/).
+
+## Cost function
+
+The cost function of this environment is designed in such a way that it tries to minimize the error between the swimmer's forward speed and a reference value. The cost function is defined as:
+
+$$
+cost = w\_{forward} \times (x\_{speed} - x\_{reference\_speed})^2 + w\_{ctrl} \times c\_{ctrl}
+$$
+
+## How to use
+
+This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:SwimmerCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/swimmer_cost/README.md
+++ b/stable_gym/envs/mujoco/swimmer_cost/README.md
@@ -5,7 +5,7 @@
 </div>
 </br>
 
-An actuated two-jointed swimmer. This environment corresponds to the [Swimmer-v2](https://gym.openai.com/envs/Swimmer-v2/) environment included in the OpenAI gym package. It is different in the fact that:
+An actuated two-jointed swimmer. This environment corresponds to the [Swimmer-v4](https://gymnasium.farama.org/environments/mujoco/swimmer) environment included in the [gymnasium package](https://gymnasium.farama.org/). It is different in the fact that:
 
 *   The objective was changed to a speed-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the swimmer's forward speed and a reference value (error).
 

--- a/stable_gym/envs/mujoco/swimmer_cost/__init__.py
+++ b/stable_gym/envs/mujoco/swimmer_cost/__init__.py
@@ -1,0 +1,9 @@
+"""Modified version of the swimmer Mujoco environment in v0.28.1 of the
+`gymnasium library <https://gymnasium.farama.org/environments/mujoco/swimmer>`_.
+This modification was first described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_.
+In this modified version:
+
+-   The objective was changed to a speed-tracking task. To do this, the reward is replaced with a cost.
+    This cost is the squared difference between the swimmer's forward speed and a reference value (error).
+"""  # noqa: E501
+from stable_gym.envs.mujoco.swimmer_cost.swimmer_cost import SwimmerCost

--- a/stable_gym/envs/mujoco/swimmer_cost/requirements.txt
+++ b/stable_gym/envs/mujoco/swimmer_cost/requirements.txt
@@ -1,3 +1,3 @@
 gymnasium==0.28.1
-gymnasium[classic_control]==0.28.1
+gymnasium[mujoco]==0.28.1
 matplotlib==3.7.0

--- a/stable_gym/envs/mujoco/swimmer_cost/swimmer_cost.py
+++ b/stable_gym/envs/mujoco/swimmer_cost/swimmer_cost.py
@@ -36,7 +36,7 @@ class SwimmerCost(SwimmerEnv):
     Modified cost:
         .. math::
 
-            cost = w_{forward} \times (x_{speed} - x_{reference\_speed})^2 + w_{ctrl} \times c_{ctrl}
+            cost = w_{forward} \\times (x_{speed} - x_{reference\_speed})^2 + w_{ctrl} \\times c_{ctrl}
 
     Solved Requirements:
         Considered solved when the average cost is less than or equal to 50 over

--- a/stable_gym/envs/mujoco/swimmer_cost/swimmer_cost.py
+++ b/stable_gym/envs/mujoco/swimmer_cost/swimmer_cost.py
@@ -1,0 +1,199 @@
+"""The SwimmerCost gymnasium environment."""
+
+import gymnasium as gym
+import matplotlib.pyplot as plt
+import numpy as np
+from gymnasium.envs.mujoco.swimmer_v4 import SwimmerEnv
+
+import stable_gym  # NOTE: Required to register environments. # noqa: F401
+
+RANDOM_STEP = True  # Use random action in __main__. Zero action otherwise.
+
+
+# TODO: Add solving criteria after training.
+class SwimmerCost(SwimmerEnv):
+    """Custom Swimmer gymnasium environment.
+
+    .. note::
+        Can also be used in a vectorized manner. See the
+        :gymnasium:`gym.vector <api/vector>` documentation.
+
+    Source:
+        This is a modified version of the swimmer Mujoco environment in v0.28.1 of the
+        :gymnasium:`gymnasium library <envs/mujoco/swimmer>`. This modification was first
+        described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_. Compared to the
+        original Swimmer environment in this modified version:
+
+        -   The objective was changed to a speed-tracking task. To do this, the reward
+            is replaced with a cost. This cost is the squared difference between the
+            swimmer's forward speed and a reference value (error).
+
+        The rest of the environment is the same as the original Swimmer environment. Below,
+        the modified cost is described. For more information about the environment
+        (e.g. observation space, action space, episode termination, etc.), please refer
+        to the :gymnasium:`gymnasium library <envs/mujoco/swimmer>`.
+
+    Modified cost:
+        .. math::
+
+            cost = w_{forward} \times (x_{speed} - x_{reference\_speed})^2 + w_{ctrl} \times c_{ctrl}
+
+    Solved Requirements:
+        Considered solved when the average cost is less than or equal to 50 over
+        100 consecutive trials.
+
+    How to use:
+        .. code-block:: python
+
+            import stable_gym
+            import gymnasium as gym
+            env = gym.make("SwimmerCost-v1")
+
+        On reset, the ``options`` parameter allows the user to change the bounds used to
+        determine the new random state when ``random=True``.
+
+    Attributes:
+        reference_speed (float): The forward speed that the agent should try to track.
+        include_ctrl_cost (bool): Whether you also want to penalize the swimmer if it
+            takes actions that are too large.
+        forward_speed_weight (float): The weight used to scale the forward speed error.
+    """  # noqa: E501, W605
+
+    def __init__(
+        self,
+        reference_forward_speed=1.0,
+        include_ctrl_cost=True,
+        forward_speed_weight=1.0,
+        ctrl_cost_weight=None,
+        **kwargs,
+    ):
+        """Constructs all the necessary attributes for the SwimmerCost instance.
+
+        Args:
+            reference_forward_speed (float, optional): The forward speed that the agent
+                should try to track. Defaults to ``1.0``.
+            include_ctrl_cost (bool, optional): Whether you also want to penalize the
+                swimmer if it takes actions that are too large. Defaults to ``True``.
+            forward_speed_weight (float, optional): The weight used to scale the forward
+                speed error. Defaults to ``1.0``.
+            ctrl_cost_weight (_type_, optional): The weight used to scale the control
+                cost. Defaults to ``None`` meaning that the default value of the
+                :attr:`~gymnasium.envs.mujoco.swimmer_v4.SwimmerEnv.ctrl_cost_weight`
+                attribute is used.
+        """
+        super().__init__(**kwargs)
+        self.reference_speed = reference_forward_speed
+        self.include_ctrl_cost = include_ctrl_cost
+        self._ctrl_cost_weight = (
+            ctrl_cost_weight if ctrl_cost_weight else self._ctrl_cost_weight
+        )
+        self.forward_speed_weight = forward_speed_weight
+        self.state = None
+
+    def step(self, action):
+        """Take step into the environment.
+
+        .. note::
+            This method overrides the
+            :meth:`~gymnasium.envs.mujoco.swimmer_v4.SwimmerEnv.step` method such that
+            the new cost function is used.
+
+        Args:
+            action (np.ndarray): Action to take in the environment.
+
+        Returns:
+            (tuple): tuple containing:
+
+                - obs (:obj:`np.ndarray`): Environment observation.
+                - cost (:obj:`float`): Cost of the action.
+                - terminated (:obj`bool`): Whether the episode is terminated.
+                - truncated (:obj:`bool`): Whether the episode was truncated. This value
+                    is set by wrappers when for example a time limit is reached or the
+                    agent goes out of bounds.
+                - info (:obj`dict`): Additional information about the environment.
+        """
+        obs, _, terminated, truncated, info = super().step(action)
+        self.state = obs
+        cost, cost_info = self.cost(info["x_velocity"], -info["reward_ctrl"])
+
+        # Update info.
+        info["reward_fwd"] = cost_info["reward_fwd"]
+        info["forward_reward"] = cost_info["reward_fwd"]
+
+        return obs, cost, terminated, truncated, info
+
+    def cost(self, x_velocity, ctrl_cost):
+        """Compute the cost of the action.
+
+        Args:
+            x_velocity (float): The swimmer's x velocity.
+            ctrl_cost (float): The control cost.
+
+        Returns:
+            (tuple): tuple containing:
+
+                - cost (float): The cost of the action.
+                - info (:obj:`dict`): Additional information about the cost.
+        """
+        reward_fwd = self.forward_speed_weight * np.square(
+            x_velocity - self.reference_speed
+        )
+        cost = reward_fwd
+        if self.include_ctrl_cost:
+            cost += ctrl_cost
+        return cost, {"reward_fwd": reward_fwd, "reward_ctrl": ctrl_cost}
+
+    @property
+    def ctrl_cost_weight(self):
+        """Property that returns the control cost weight."""
+        return self._ctrl_cost_weight
+
+    @ctrl_cost_weight.setter
+    def ctrl_cost_weight(self, value):
+        """Setter for the control cost weight."""
+        self._ctrl_cost_weight = value
+
+
+if __name__ == "__main__":
+    print("Setting up SwimmerCost environment.")
+    env = gym.make("SwimmerCost", render_mode="human")
+
+    # Take T steps in the environment.
+    T = 1000
+    path = []
+    t1 = []
+    s = env.reset(
+        options={
+            "low": [-2, -0.2, -0.2, -0.2],
+            "high": [2, 0.2, 0.2, 0.2],
+        }
+    )
+    print(f"Taking {T} steps in the SwimmerCost environment.")
+    for i in range(int(T / env.dt)):
+        action = (
+            env.action_space.sample()
+            if RANDOM_STEP
+            else np.zeros(env.action_space.shape)
+        )
+        s, r, terminated, truncated, info = env.step(action)
+        if terminated:
+            env.reset()
+        path.append(s)
+        t1.append(i * env.dt)
+    print("Finished SwimmerCost environment simulation.")
+
+    # Plot results.
+    print("Plot results.")
+    fig = plt.figure(figsize=(9, 6))
+    ax = fig.add_subplot(111)
+    ax.plot(t1, np.array(path)[:, 0], color="orange", label="x")
+    ax.plot(t1, np.array(path)[:, 1], color="magenta", label="x_dot")
+    ax.plot(t1, np.array(path)[:, 2], color="sienna", label="theta")
+    ax.plot(t1, np.array(path)[:, 3], color="blue", label=" theat_dot1")
+
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels, loc=2, fancybox=False, shadow=False)
+    plt.ioff()
+    plt.show()
+
+    print("done")

--- a/stable_gym/envs/mujoco/swimmer_cost/swimmer_cost.py
+++ b/stable_gym/envs/mujoco/swimmer_cost/swimmer_cost.py
@@ -20,7 +20,7 @@ class SwimmerCost(SwimmerEnv):
 
     Source:
         This is a modified version of the swimmer Mujoco environment in v0.28.1 of the
-        :gymnasium:`gymnasium library <envs/mujoco/swimmer>`. This modification was first
+        :gymnasium:`gymnasium library <environments/mujoco/swimmer>`. This modification was first
         described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_. Compared to the
         original Swimmer environment in this modified version:
 
@@ -31,7 +31,7 @@ class SwimmerCost(SwimmerEnv):
         The rest of the environment is the same as the original Swimmer environment. Below,
         the modified cost is described. For more information about the environment
         (e.g. observation space, action space, episode termination, etc.), please refer
-        to the :gymnasium:`gymnasium library <envs/mujoco/swimmer>`.
+        to the :gymnasium:`gymnasium library <environments/mujoco/swimmer>`.
 
     Modified cost:
         .. math::

--- a/tests/test_cart_pole.py
+++ b/tests/test_cart_pole.py
@@ -2,6 +2,7 @@
 environment when the same environment parameters are used.
 """
 import math
+import random
 
 import gymnasium as gym
 import numpy as np
@@ -40,18 +41,17 @@ class TestCartPoleCostEqual:
 
     def test_equal_steps(self):
         """Test if steps behave the same."""
-        # Perform steps and check if observations are equal.
-        observation, _, _, _, _ = self.env.step(0)
-        observation_cost, _, _, _, _ = self.env_cost.step(
-            np.array([-10], dtype=np.float32)
-        )
-        assert np.allclose(
-            observation, observation_cost
-        ), f"{observation} != {observation_cost}"
-        observation, _, _, _, _ = self.env.step(1)
-        observation_cost, _, _, _, _ = self.env_cost.step(
-            np.array([10], dtype=np.float32)
-        )
-        assert np.allclose(
-            observation, observation_cost
-        ), f"{observation} != {observation_cost}"
+        # Perform several steps and check if observations are equal.
+        self.env.reset(seed=42), self.env_cost.reset(seed=42)
+        for _ in range(10):
+            discrete_action = random.randint(0, 1)
+            continuous_action = (
+                np.array([-10], dtype=np.float32)
+                if discrete_action == 0
+                else np.array([10], dtype=np.float32)
+            )
+            observation, _, _, _, _ = self.env.step(discrete_action)
+            observation_cost, _, _, _, _ = self.env_cost.step(continuous_action)
+            assert np.allclose(
+                observation, observation_cost
+            ), f"{observation} != {observation_cost}"

--- a/tests/test_swimmer_cost.py
+++ b/tests/test_swimmer_cost.py
@@ -1,0 +1,39 @@
+"""Test if the SwimmerCost environment still behaves like the original Swimmer
+environment when the same environment parameters are used.
+"""
+import gymnasium as gym
+import numpy as np
+from gymnasium.logger import ERROR
+
+import stable_gym  # noqa: F401
+
+gym.logger.set_level(ERROR)
+
+
+class TestCartPoleCostEqual:
+    # Make original Swimmer environment.
+    env = gym.make("Swimmer")
+    # Make SwimmerCost environment.
+    env_cost = gym.make("SwimmerCost")
+
+    def test_equal_reset(self):
+        """Test if reset behaves the same."""
+        # Perform reset and check if observations are equal.
+        observation, _ = self.env.reset(seed=42)
+        observation_cost, _ = self.env_cost.reset(seed=42)
+        assert np.allclose(
+            observation, observation_cost
+        ), f"{observation} != {observation_cost}"
+
+    def test_equal_steps(self):
+        """Test if steps behave the same."""
+        # Perform several steps and check if observations are equal.
+        self.env.reset(seed=42), self.env_cost.reset(seed=42)
+        for _ in range(10):
+            self.env.action_space.seed(42)
+            action = self.env.action_space.sample()
+            observation, _, _, _, _ = self.env.step(action)
+            observation_cost, _, _, _, _ = self.env_cost.step(action)
+            assert np.allclose(
+                observation, observation_cost
+            ), f"{observation} != {observation_cost}"

--- a/tests/test_swimmer_cost.py
+++ b/tests/test_swimmer_cost.py
@@ -10,7 +10,7 @@ import stable_gym  # noqa: F401
 gym.logger.set_level(ERROR)
 
 
-class TestCartPoleCostEqual:
+class TestSwimmerCostEqual:
     # Make original Swimmer environment.
     env = gym.make("Swimmer")
     # Make SwimmerCost environment.


### PR DESCRIPTION
This pull request adds the SwimmerCost environment. This environment was based on the [swimmer environment](https://gymnasium.farama.org/environments/mujoco/swimmer/) of the [gymnasium library](https://gymnasium.farama.org). Compared to that environment, only the reward was changed so that a reference speed was tracked.
