### PR TITLE
feat: add 'HalfCheetahCost' environment

### DIFF
--- a/stable_gym/__init__.py
+++ b/stable_gym/__init__.py
@@ -33,6 +33,11 @@ ENVS = {
         "max_step": 250,
         "reward_threshold": 300,
     },
+    "HalfCheetahCost-v1": {
+        "module": "stable_gym.envs.mujoco.half_cheetah_cost.half_cheetah_cost:HalfCheetahCost",
+        "max_step": 200,
+        "reward_threshold": 300,
+    },
 }
 
 for env, val in ENVS.items():

--- a/stable_gym/envs/mujoco/half_cheetah_cost/README.md
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/README.md
@@ -1,0 +1,25 @@
+# HalfCheetahCost gymnasium environment
+
+<div align="center">
+    <img src="https://github.com/rickstaa/stable-gym/assets/17570430/44360980-3ad1-40e9-863e-3417ed3aa4c8" alt="Half Cheetah" width="200px">
+</div>
+</br>
+
+An actuated 8-jointed half cheetah. This environment corresponds to the [HalfCheetah-v4](https://gymnasium.farama.org/environments/mujoco/half_cheetah) environment included in the [gymnasium package](https://gymnasium.farama.org/). It is different in the fact that:
+
+*   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost. This cost is the squared
+    difference between the HalfCheetah's forward velocity and a reference value (error).
+
+The rest of the environment is the same as the original HalfCheetah environment. Below, the modified cost is described. For more information about the environment (e.g. observation space, action space, episode termination, etc.), please refer to the [gymnasium library](https://gymnasium.farama.org/environments/mujoco/half_cheetah/).
+
+## Cost function
+
+The cost function of this environment is designed in such a way that it tries to minimize the error between the HalfCheetah's forward velocity and a reference value. The cost function is defined as:
+
+$$
+cost = w\_{forward} \times (x\_{velocity} - x\_{reference\_x\_velocity})^2 + w\_{ctrl} \times c\_{ctrl}
+$$
+
+## How to use
+
+This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:HalfCheetahCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/half_cheetah_cost/__init__.py
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/__init__.py
@@ -1,0 +1,9 @@
+"""Modified version of the HalfCheetah Mujoco environment in v0.28.1 of the
+`gymnasium library <https://gymnasium.farama.org/environments/mujoco/half_cheetah>`_.
+This modification was first described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_.
+In this modified version:
+
+-   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost.
+    This cost is the squared difference between the HalfCheetah's forward velocity and a reference value (error).
+"""  # noqa: E501
+from stable_gym.envs.mujoco.half_cheetah_cost.half_cheetah_cost import HalfCheetahCost

--- a/stable_gym/envs/mujoco/half_cheetah_cost/half_cheetah_cost.py
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/half_cheetah_cost.py
@@ -1,9 +1,9 @@
-"""The SwimmerCost gymnasium environment."""
+"""The HalfCheetahCost gymnasium environment."""
 
 import gymnasium as gym
 import matplotlib.pyplot as plt
 import numpy as np
-from gymnasium.envs.mujoco.swimmer_v4 import SwimmerEnv
+from gymnasium.envs.mujoco.half_cheetah_v4 import HalfCheetahEnv
 
 import stable_gym  # NOTE: Required to register environments. # noqa: F401
 
@@ -11,27 +11,27 @@ RANDOM_STEP = True  # Use random action in __main__. Zero action otherwise.
 
 
 # TODO: Add solving criteria after training.
-class SwimmerCost(SwimmerEnv):
-    """Custom Swimmer gymnasium environment.
+class HalfCheetahCost(HalfCheetahEnv):
+    """Custom HalfCheetah gymnasium environment.
 
     .. note::
         Can also be used in a vectorized manner. See the
         :gymnasium:`gym.vector <api/vector>` documentation.
 
     Source:
-        This is a modified version of the swimmer Mujoco environment in v0.28.1 of the
-        :gymnasium:`gymnasium library <environments/mujoco/swimmer>`. This modification was
-        first described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_. Compared
-        to the original Swimmer environment in this modified version:
+        This is a modified version of the HalfCheetah Mujoco environment in v0.28.1 of the
+        :gymnasium:`gymnasium library <environments/mujoco/half_cheetah>`. This modification
+        was first described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_.
+        Compared to the original HalfCheetah environment in this modified version:
 
         -   The objective was changed to a velocity-tracking task. To do this, the reward
             is replaced with a cost. This cost is the squared difference between the
-            swimmer's forward velocity and a reference value (error).
+            HalfCheetah's forward velocity and a reference value (error).
 
-        The rest of the environment is the same as the original Swimmer environment.
+        The rest of the environment is the same as the original HalfCheetah environment.
         Below, the modified cost is described. For more information about the environment
         (e.g. observation space, action space, episode termination, etc.), please refer
-        to the :gymnasium:`gymnasium library <environments/mujoco/swimmer>`.
+        to the :gymnasium:`gymnasium library <environments/mujoco/half_cheetah>`.
 
     Modified cost:
         .. math::
@@ -47,12 +47,12 @@ class SwimmerCost(SwimmerEnv):
 
             import stable_gym
             import gymnasium as gym
-            env = gym.make("SwimmerCost-v1")
+            env = gym.make("HalfCheetahCost-v1")
 
     Attributes:
         reference_forward_velocity (float): The forward velocity that the agent should try
             to track.
-        include_ctrl_cost (bool): Whether you also want to penalize the swimmer if it
+        include_ctrl_cost (bool): Whether you also want to penalize the HalfCheetah if it
             takes actions that are too large.
         forward_velocity_weight (float): The weight used to scale the forward velocity error.
     """  # noqa: E501, W605
@@ -65,20 +65,20 @@ class SwimmerCost(SwimmerEnv):
         ctrl_cost_weight=None,
         **kwargs,
     ):
-        """Constructs all the necessary attributes for the SwimmerCost instance.
+        """Constructs all the necessary attributes for the HalfCheetahCost instance.
 
         Args:
             reference_forward_velocity (float, optional): The forward velocity that the
                 agent should try to track. Defaults to ``1.0``.
             include_ctrl_cost (bool, optional): Whether you also want to penalize the
-                swimmer if it takes actions that are too large. Defaults to ``True``.
+                HalfCheetah if it takes actions that are too large. Defaults to ``True``.
             forward_velocity_weight (float, optional): The weight used to scale the
                 forward velocity error. Defaults to ``1.0``.
             ctrl_cost_weight (_type_, optional): The weight used to scale the control
                 cost. Defaults to ``None`` meaning that the default value of the
-                :attr:`~gymnasium.envs.mujoco.swimmer_v4.SwimmerEnv.ctrl_cost_weight`
+                :attr:`~gymnasium.envs.mujoco.half_cheetah_v4.HalfCheetahEnv.ctrl_cost_weight`
                 attribute is used.
-        """
+        """  # noqa: E501
         super().__init__(**kwargs)
         self.reference_forward_velocity = reference_forward_velocity
         self.include_ctrl_cost = include_ctrl_cost
@@ -93,8 +93,8 @@ class SwimmerCost(SwimmerEnv):
 
         .. note::
             This method overrides the
-            :meth:`~gymnasium.envs.mujoco.swimmer_v4.SwimmerEnv.step` method such that
-            the new cost function is used.
+            :meth:`~gymnasium.envs.mujoco.half_cheetah_v4.HalfCheetahEnv.step` method
+            such that the new cost function is used.
 
         Args:
             action (np.ndarray): Action to take in the environment.
@@ -124,7 +124,7 @@ class SwimmerCost(SwimmerEnv):
         """Compute the cost of the action.
 
         Args:
-            x_velocity (float): The swimmer's x velocity.
+            x_velocity (float): The HalfCheetah's x velocity.
             ctrl_cost (float): The control cost.
 
         Returns:
@@ -153,8 +153,8 @@ class SwimmerCost(SwimmerEnv):
 
 
 if __name__ == "__main__":
-    print("Setting up SwimmerCost environment.")
-    env = gym.make("SwimmerCost", render_mode="human")
+    print("Setting up HalfCheetahCost environment.")
+    env = gym.make("HalfCheetahCost", render_mode="human")
 
     # Take T steps in the environment.
     T = 1000
@@ -166,7 +166,7 @@ if __name__ == "__main__":
             "high": [2, 0.2, 0.2, 0.2],
         }
     )
-    print(f"Taking {T} steps in the SwimmerCost environment.")
+    print(f"Taking {T} steps in the HalfCheetahCost environment.")
     for i in range(int(T / env.dt)):
         action = (
             env.action_space.sample()
@@ -178,7 +178,7 @@ if __name__ == "__main__":
             env.reset()
         path.append(s)
         t1.append(i * env.dt)
-    print("Finished SwimmerCost environment simulation.")
+    print("Finished HalfCheetahCost environment simulation.")
 
     # Plot results.
     print("Plot results.")

--- a/stable_gym/envs/mujoco/half_cheetah_cost/requirements.txt
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/requirements.txt
@@ -1,0 +1,3 @@
+gymnasium==0.28.1
+gymnasium[mujoco]==0.28.1
+matplotlib==3.7.0

--- a/stable_gym/envs/mujoco/swimmer_cost/README.md
+++ b/stable_gym/envs/mujoco/swimmer_cost/README.md
@@ -7,16 +7,16 @@
 
 An actuated two-jointed swimmer. This environment corresponds to the [Swimmer-v4](https://gymnasium.farama.org/environments/mujoco/swimmer) environment included in the [gymnasium package](https://gymnasium.farama.org/). It is different in the fact that:
 
-*   The objective was changed to a speed-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the swimmer's forward speed and a reference value (error).
+*   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the Swimmer's forward velocity and a reference value (error).
 
 The rest of the environment is the same as the original Swimmer environment. Below, the modified cost is described. For more information about the environment (e.g. observation space, action space, episode termination, etc.), please refer to the [gymnasium library](https://gymnasium.farama.org/environments/mujoco/swimmer/).
 
 ## Cost function
 
-The cost function of this environment is designed in such a way that it tries to minimize the error between the swimmer's forward speed and a reference value. The cost function is defined as:
+The cost function of this environment is designed in such a way that it tries to minimize the error between the Swimmer's forward velocity and a reference value. The cost function is defined as:
 
 $$
-cost = w\_{forward} \times (x\_{speed} - x\_{reference\_speed})^2 + w\_{ctrl} \times c\_{ctrl}
+cost = w\_{forward} \times (x\_{velocity} - x\_{reference\_x\_velocity})^2 + w\_{ctrl} \times c\_{ctrl}
 $$
 
 ## How to use

--- a/stable_gym/envs/mujoco/swimmer_cost/__init__.py
+++ b/stable_gym/envs/mujoco/swimmer_cost/__init__.py
@@ -3,7 +3,7 @@
 This modification was first described by `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_.
 In this modified version:
 
--   The objective was changed to a speed-tracking task. To do this, the reward is replaced with a cost.
-    This cost is the squared difference between the swimmer's forward speed and a reference value (error).
+-   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost.
+    This cost is the squared difference between the swimmer's forward velocity and a reference value (error).
 """  # noqa: E501
 from stable_gym.envs.mujoco.swimmer_cost.swimmer_cost import SwimmerCost

--- a/tests/test_half_cheetah_cost.py
+++ b/tests/test_half_cheetah_cost.py
@@ -1,0 +1,39 @@
+"""Test if the HalfCheetahCost environment still behaves like the original HalfCheetah
+environment when the same environment parameters are used.
+"""
+import gymnasium as gym
+import numpy as np
+from gymnasium.logger import ERROR
+
+import stable_gym  # noqa: F401
+
+gym.logger.set_level(ERROR)
+
+
+class TestHalfCheetahCostEqual:
+    # Make original HalfCheetah environment.
+    env = gym.make("HalfCheetah")
+    # Make HalfCheetahCost environment.
+    env_cost = gym.make("HalfCheetahCost")
+
+    def test_equal_reset(self):
+        """Test if reset behaves the same."""
+        # Perform reset and check if observations are equal.
+        observation, _ = self.env.reset(seed=42)
+        observation_cost, _ = self.env_cost.reset(seed=42)
+        assert np.allclose(
+            observation, observation_cost
+        ), f"{observation} != {observation_cost}"
+
+    def test_equal_steps(self):
+        """Test if steps behave the same."""
+        # Perform several steps and check if observations are equal.
+        self.env.reset(seed=42), self.env_cost.reset(seed=42)
+        for _ in range(10):
+            self.env.action_space.seed(42)
+            action = self.env.action_space.sample()
+            observation, _, _, _, _ = self.env.step(action)
+            observation_cost, _, _, _, _ = self.env_cost.step(action)
+            assert np.allclose(
+                observation, observation_cost
+            ), f"{observation} != {observation_cost}"


### PR DESCRIPTION
This pull request adds a modified version of the [HalfCeetah environment](https://gymnasium.farama.org/environments/mujoco/half_cheetah/) found in the [gymnasium](https://gymnasium.farama.org) package. In this modified version, the cost was replaced by a reward. This cost is the squared difference between HalfCheetah's forward velocity and a reference value (error).
