### PR TITLE
feat: fix 'reward_range' name and space accuracy

### DIFF
--- a/stable_gym/envs/biological/oscillator_complicated/oscillator_complicated.py
+++ b/stable_gym/envs/biological/oscillator_complicated/oscillator_complicated.py
@@ -144,7 +144,7 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
         reference_constraint_position=20.0,
         clip_action=True,
         exclude_reference_from_observation=False,
-        exclude_reference_error_from_observation=False,
+        exclude_reference_error_from_observation=True,
     ):
         """Initialise a new OscillatorComplicated environment instance.
 
@@ -168,7 +168,7 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
                 should be excluded from the observation. Defaults to ``False``. Can only
                 be set to ``True`` if ``reference_type`` is ``constant``.
             exclude_reference_error_from_observation (bool, optional): Whether the error
-                should be excluded from the observation. Defaults to ``False``.
+                should be excluded from the observation. Defaults to ``True``.
         """
         super().__init__()  # Setup disturber.
         self._action_clip_warning = False
@@ -184,8 +184,8 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
                 "The reference type must be either 'constant' or 'periodic'."
             )
         assert (
-            reference_type.lower() == "periodic"
-            or reference_type.lower() == "constant"
+            reference_type.lower() == "constant"
+            or reference_type.lower() == "periodic"
             and not exclude_reference_from_observation
         ), (
             "The reference can only be excluded from the observation if the reference "
@@ -240,25 +240,21 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
         self.delta7 = 0.0  # p3 noise.
         self.delta8 = 0.0  # p4 noise.
 
-        obs_low = np.array([0, 0, 0, 0, 0, 0, 0, 0], dtype=np.float32)
-        obs_high = np.array([100, 100, 100, 100, 100, 100, 100, 100], dtype=np.float32)
+        obs_low = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        obs_high = np.array([100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0])
         if not self._exclude_reference_from_observation:
-            obs_low = np.append(obs_low, 0.0).astype(np.float32)
-            obs_high = np.append(obs_high, 100.0).astype(np.float32)
+            obs_low = np.append(obs_low, 0.0)
+            obs_high = np.append(obs_high, 100.0)
         if not self._exclude_reference_error_from_observation:
-            obs_low = np.append(obs_low, -100).astype(np.float32)
-            obs_high = np.append(obs_high, 100).astype(np.float32)
+            obs_low = np.append(obs_low, -100.0)
+            obs_high = np.append(obs_high, 100.0)
         self.action_space = spaces.Box(
-            low=np.array([-5.0, -5.0, -5.0, -5.0], dtype=np.float32),
-            high=np.array([5.0, 5.0, 5.0, 5.0], dtype=np.float32),
-            dtype=np.float32,
+            low=np.array([-5.0, -5.0, -5.0, -5.0]),
+            high=np.array([5.0, 5.0, 5.0, 5.0]),
+            dtype=np.float64,
         )
-        self.observation_space = spaces.Box(obs_low, obs_high, dtype=np.float32)
-        self.cost_range = spaces.Box(
-            np.array([0.0], dtype=np.float32),
-            np.array([100], dtype=np.float32),
-            dtype=np.float32,
-        )
+        self.observation_space = spaces.Box(obs_low, obs_high, dtype=np.float64)
+        self.reward_range = (0.0, 100.0)
 
         self.viewer = None
         self.state = None
@@ -418,14 +414,14 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
         cost = np.square(p1 - r1)
 
         # Define stopping criteria.
-        terminated = bool(cost > self.cost_range.high or cost < self.cost_range.low)
+        terminated = cost < self.reward_range[0] or cost > self.reward_range[1]
 
         # Create observation.
-        obs = np.array([m1, m2, m3, m4, p1, p2, p3, p4], dtype=np.float32)
+        obs = np.array([m1, m2, m3, m4, p1, p2, p3, p4])
         if not self._exclude_reference_from_observation:
-            obs = np.append(obs, r1).astype(np.float32)
+            obs = np.append(obs, r1)
         if not self._exclude_reference_error_from_observation:
-            obs = np.append(obs, p1 - r1).astype(np.float32)
+            obs = np.append(obs, p1 - r1)
 
         # Return state, cost, terminated, truncated and info_dict
         return (
@@ -476,33 +472,25 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
         low = np.array(
             options["low"]
             if options is not None and "low" in options
-            else self._init_state_range["low"],
-            dtype=np.float32,
+            else self._init_state_range["low"]
         )
         high = np.array(
             options["high"]
             if options is not None and "high" in options
-            else self._init_state_range["high"],
-            dtype=np.float32,
+            else self._init_state_range["high"]
         )
         assert (
             self.observation_space.contains(
                 np.append(
                     low,
-                    np.zeros(
-                        self.observation_space.shape[0] - low.shape[0],
-                        dtype=np.float32,
-                    ),
+                    np.zeros(self.observation_space.shape[0] - low.shape[0]),
                 )
             )
         ) and (
             self.observation_space.contains(
                 np.append(
                     high,
-                    np.zeros(
-                        self.observation_space.shape[0] - low.shape[0],
-                        dtype=np.float32,
-                    ),
+                    np.zeros(self.observation_space.shape[0] - high.shape[0]),
                 )
             )
         ), (
@@ -519,11 +507,11 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
         self.t = 0.0
         m1, m2, m3, m4, p1, p2, p3, p4 = self.state
         r1 = self.reference(self.t)
-        obs = np.array([m1, m2, m3, m4, p1, p2, p3, p4], dtype=np.float32)
+        obs = np.array([m1, m2, m3, m4, p1, p2, p3, p4])
         if not self._exclude_reference_from_observation:
-            obs = np.append(obs, r1).astype(np.float32)
+            obs = np.append(obs, r1)
         if not self._exclude_reference_error_from_observation:
-            obs = np.append(obs, p1 - r1).astype(np.float32)
+            obs = np.append(obs, p1 - r1)
 
         # Return initial observation and info_dict.
         return obs, dict(

--- a/stable_gym/envs/classic_control/ex3_ekf/ex3_ekf.py
+++ b/stable_gym/envs/classic_control/ex3_ekf/ex3_ekf.py
@@ -128,11 +128,7 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
             dtype=np.float32,
         )
         self.observation_space = spaces.Box(-high, high, dtype=np.float32)
-        self.cost_range = spaces.Box(
-            np.array([0.0], dtype=np.float32),
-            np.array([100], dtype=np.float32),
-            dtype=np.float32,
-        )
+        self.reward_range = (0.0, 100.0)
 
         self._clipped_action = clipped_action
         self.viewer = None
@@ -214,7 +210,7 @@ class Ex3EKF(gym.Env, Ex3EKFDisturber):
         # cost = np.abs(hat_x_1 - x_1)**1 + np.abs(hat_x_2 - x_2)**1
 
         # Define stopping criteria.
-        terminated = bool(cost > self.cost_range.high or cost < self.cost_range.low)
+        terminated = cost < self.reward_range[0] or cost > self.reward_range[1]
 
         # Update state.
         self.state = np.array([hat_x_1, hat_x_2, x_1, x_2])

--- a/tests/__snapshots__/test_cart_pole.ambr
+++ b/tests/__snapshots__/test_cart_pole.ambr
@@ -1,9 +1,435 @@
 # serializer version: 1
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot
+  0.10958241942238534
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.1
+  -0.024448624099179084
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.10
+  -0.19298094228082074
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.11
+  0.004398229425633801
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.12
+  0.10469521751476796
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.13
+  0.3836554311534694
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.14
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.15
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.16
+  dict({
+    'reference': 0.004398229425633801,
+    'reference_constraint_error': -3.8909065530595983,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10469521751476796,
+    'state_of_interest': 0.10909344694040175,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.17
+  0.11283397455824112
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.18
+  0.1373521677359711
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.19
+  0.14115849335141145
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.2
+  0.14343916796455297
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.20
+  -0.07676570293056856
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.21
+  0.00879645711491628
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.22
+  0.10403751744332485
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.23
+  0.3635097988816521
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.24
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.25
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.26
+  dict({
+    'reference': 0.00879645711491628,
+    'reference_constraint_error': -3.887166025441759,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10403751744332485,
+    'state_of_interest': 0.11283397455824112,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.27
+  0.11558101791296055
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.28
+  0.41483476162456334
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.29
+  0.13962317929280008
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.3
+  0.07894721162374557
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.30
+  -0.44748678167775646
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.31
+  0.013194681331496795
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.32
+  0.10238633658146376
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.33
+  0.35564428719480884
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.34
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.35
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.36
+  dict({
+    'reference': 0.013194681331496795,
+    'reference_constraint_error': -3.8844189820870394,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10238633658146376,
+    'state_of_interest': 0.11558101791296055,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.37
+  0.12387771314545182
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.38
+  0.5667135704060806
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.39
+  0.13067344365924494
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.4
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.40
+  -0.6321720124467993
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.41
+  0.01759290033902609
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.42
+  0.10628481280642572
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.43
+  0.3115336328691423
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.44
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.45
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.46
+  dict({
+    'reference': 0.01759290033902609,
+    'reference_constraint_error': -3.876122286854548,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10628481280642572,
+    'state_of_interest': 0.12387771314545182,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.47
+  0.13521198455357342
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.48
+  0.24856720024803347
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.49
+  0.11803000341030895
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.5
+  0.10958241942238534
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.50
+  -0.12071230469371952
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.51
+  0.021991112401156945
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.52
+  0.11322087215241647
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.53
+  0.25420065345796333
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.54
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.55
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.56
+  dict({
+    'reference': 0.021991112401156945,
+    'reference_constraint_error': -3.8647880154464267,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11322087215241647,
+    'state_of_interest': 0.13521198455357342,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.6
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8904175805776147,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10958241942238534,
+    'state_of_interest': 0.10958241942238534,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.7
+  0.10909344694040175
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.8
+  0.18702638089196827
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_periodic_snapshot.9
+  0.14501811219702787
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot
+  0.10958241942238534
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.1
+  -0.024448624099179084
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.10
+  -0.19298094228082074
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.11
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.12
+  0.10909344694040175
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.13
+  0.3836648340694181
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.14
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.15
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.16
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8909065530595983,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10909344694040175,
+    'state_of_interest': 0.10909344694040175,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.17
+  0.11283397455824112
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.18
+  0.1373521677359711
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.19
+  0.14115849335141145
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.2
+  0.14343916796455297
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.20
+  -0.07676570293056856
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.21
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.22
+  0.11283397455824112
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.23
+  0.3635288758894405
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.24
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.25
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.26
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.887166025441759,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11283397455824112,
+    'state_of_interest': 0.11283397455824112,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.27
+  0.11558101791296055
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.28
+  0.41483476162456334
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.29
+  0.13962317929280008
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.3
+  0.07894721162374557
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.30
+  -0.44748678167775646
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.31
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.32
+  0.11558101791296055
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.33
+  0.35567304729264104
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.34
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.35
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.36
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8844189820870394,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11558101791296055,
+    'state_of_interest': 0.11558101791296055,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.37
+  0.12387771314545182
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.38
+  0.5667135704060806
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.39
+  0.13067344365924494
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.4
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.40
+  -0.6321720124467993
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.41
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.42
+  0.12387771314545182
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.43
+  0.3115741251329508
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.44
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.45
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.46
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.876122286854548,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.12387771314545182,
+    'state_of_interest': 0.12387771314545182,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.47
+  0.13521198455357342
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.48
+  0.24856720024803347
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.49
+  0.11803000341030895
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.5
+  0.10958241942238534
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.50
+  -0.12071230469371952
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.51
+  0.0
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.52
+  0.13521198455357342
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.53
+  0.254255286606723
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.54
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.55
+  False
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.56
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8647880154464267,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.13521198455357342,
+    'state_of_interest': 0.13521198455357342,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.6
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8904175805776147,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10958241942238534,
+    'state_of_interest': 0.10958241942238534,
+  })
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.7
+  0.10909344694040175
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.8
+  0.18702638089196827
+# ---
+# name: TestCartPoleCostEqual.test_reference_tracking_snapshot.9
+  0.14501811219702787
+# ---
 # name: TestCartPoleCostEqual.test_snapshot
-  0.02739560604095459
+  0.027395604855596334
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.1
-  -0.006112155970185995
+  -0.006112156024794771
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.10
   False
@@ -14,27 +440,27 @@
 # name: TestCartPoleCostEqual.test_snapshot.12
   dict({
     'reference': 0.0,
-    'reference_constraint_error': -3.9727266378584947,
+    'reference_constraint_error': -3.9727266382648994,
     'reference_constraint_position': 4.0,
     'reference_constraint_violated': False,
-    'reference_error': 0.027273362141505202,
-    'state_of_interest': 0.027273362141505202,
+    'reference_error': 0.02727336173510044,
+    'state_of_interest': 0.02727336173510044,
   })
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.13
-  0.03141682967543602
+  0.03141682796673494
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.14
-  0.15895679593086243
+  0.1589567895008271
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.15
-  0.03046562522649765
+  0.03046562406312443
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.16
-  -0.2065114676952362
+  -0.20651144607254457
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.17
-  0.4233589569570663
+  0.42335894938624435
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.18
   False
@@ -43,32 +469,32 @@
   False
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.2
-  0.03585979342460632
+  0.03585979199113824
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.20
   dict({
     'reference': 0.0,
-    'reference_constraint_error': -3.9685831714438327,
+    'reference_constraint_error': -3.968583172033265,
     'reference_constraint_position': 4.0,
     'reference_constraint_violated': False,
-    'reference_error': 0.03141682855616748,
-    'state_of_interest': 0.03141682855616748,
+    'reference_error': 0.03141682796673494,
+    'state_of_interest': 0.03141682796673494,
   })
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.21
-  0.03459596633911133
+  0.03459596375675149
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.22
-  0.4383837580680847
+  0.43838373784361623
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.23
-  0.026335395872592926
+  0.02633539514167354
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.24
-  -0.6165018677711487
+  -0.6165018621732461
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.25
-  0.31643005730946416
+  0.31643005773596056
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.26
   False
@@ -79,30 +505,30 @@
 # name: TestCartPoleCostEqual.test_snapshot.28
   dict({
     'reference': 0.0,
-    'reference_constraint_error': -3.9654040354536884,
+    'reference_constraint_error': -3.9654040362432483,
     'reference_constraint_position': 4.0,
     'reference_constraint_violated': False,
-    'reference_error': 0.034595964546311656,
-    'state_of_interest': 0.034595964546311656,
+    'reference_error': 0.03459596375675149,
+    'state_of_interest': 0.03459596375675149,
   })
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.29
-  0.04336363822221756
+  0.04336363851362381
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.3
-  0.01973680406808853
+  0.019736802905936393
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.30
-  0.5920515656471252
+  0.5920515317536212
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.31
-  0.014005357399582863
+  0.014005357898208616
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.32
-  -0.8391819000244141
+  -0.8391819138660229
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.33
-  0.08976015310589762
+  0.08976015773011449
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.34
   False
@@ -113,37 +539,37 @@
 # name: TestCartPoleCostEqual.test_snapshot.36
   dict({
     'reference': 0.0,
-    'reference_constraint_error': -3.9566363604590937,
+    'reference_constraint_error': -3.956636361486376,
     'reference_constraint_position': 4.0,
     'reference_constraint_violated': False,
-    'reference_error': 0.0433636395409062,
-    'state_of_interest': 0.0433636395409062,
+    'reference_error': 0.04336363851362381,
+    'state_of_interest': 0.04336363851362381,
   })
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.37
-  0.05520467087626457
+  0.05520466914869624
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.38
-  0.2751252353191376
+  0.2751252402092573
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.39
-  -0.0027782809920608997
+  -0.002778280379111842
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.4
   dict({
     'reference': 0.0,
-    'reference_constraint_error': -3.9726043947361775,
+    'reference_constraint_error': -3.972604395144404,
     'reference_constraint_position': 4.0,
     'reference_constraint_violated': False,
-    'reference_error': 0.02739560526382266,
-    'state_of_interest': 0.02739560526382266,
+    'reference_error': 0.027395604855596334,
+    'state_of_interest': 0.027395604855596334,
   })
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.40
-  -0.35972166061401367
+  -0.3597216590053294
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.41
-  0.004048460993187186
+  0.004048459369276578
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.42
   False
@@ -154,25 +580,25 @@
 # name: TestCartPoleCostEqual.test_snapshot.44
   dict({
     'reference': 0.0,
-    'reference_constraint_error': -3.9447953296374747,
+    'reference_constraint_error': -3.9447953308513037,
     'reference_constraint_position': 4.0,
     'reference_constraint_violated': False,
-    'reference_error': 0.05520467036252527,
-    'state_of_interest': 0.05520467036252527,
+    'reference_error': 0.05520466914869624,
+    'state_of_interest': 0.05520466914869624,
   })
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.5
-  0.02727336250245571
+  0.02727336173510044
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.6
-  0.20717331767082214
+  0.20717331158172525
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.7
-  0.036254528909921646
+  0.03625452804925697
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.8
-  -0.2894452214241028
+  -0.2894451993066269
 # ---
 # name: TestCartPoleCostEqual.test_snapshot.9
-  0.5994195002721167
+  0.5994194824080236
 # ---

--- a/tests/__snapshots__/test_oscillator.ambr
+++ b/tests/__snapshots__/test_oscillator.ambr
@@ -1,27 +1,204 @@
 # serializer version: 1
+# name: TestOscillator.test_constant_snapshot
+  0.10958241942238534
+# ---
+# name: TestOscillator.test_constant_snapshot.1
+  -0.024448624099179084
+# ---
+# name: TestOscillator.test_constant_snapshot.10
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.11
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.12
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8909065530595983,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10909344694040175,
+    'state_of_interest': 0.10909344694040175,
+  })
+# ---
+# name: TestOscillator.test_constant_snapshot.13
+  0.11283397455824112
+# ---
+# name: TestOscillator.test_constant_snapshot.14
+  0.1373521677359711
+# ---
+# name: TestOscillator.test_constant_snapshot.15
+  0.14115849335141145
+# ---
+# name: TestOscillator.test_constant_snapshot.16
+  -0.07676570293056856
+# ---
+# name: TestOscillator.test_constant_snapshot.17
+  3.270741362539796
+# ---
+# name: TestOscillator.test_constant_snapshot.18
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.19
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.2
+  0.14343916796455297
+# ---
+# name: TestOscillator.test_constant_snapshot.20
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.887166025441759,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11283397455824112,
+    'state_of_interest': 0.11283397455824112,
+  })
+# ---
+# name: TestOscillator.test_constant_snapshot.21
+  0.11558101791296055
+# ---
+# name: TestOscillator.test_constant_snapshot.22
+  0.41483476162456334
+# ---
+# name: TestOscillator.test_constant_snapshot.23
+  0.13962317929280008
+# ---
+# name: TestOscillator.test_constant_snapshot.24
+  -0.44748678167775646
+# ---
+# name: TestOscillator.test_constant_snapshot.25
+  3.199988707897624
+# ---
+# name: TestOscillator.test_constant_snapshot.26
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.27
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.28
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8844189820870394,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11558101791296055,
+    'state_of_interest': 0.11558101791296055,
+  })
+# ---
+# name: TestOscillator.test_constant_snapshot.29
+  0.12387771314545182
+# ---
+# name: TestOscillator.test_constant_snapshot.3
+  0.07894721162374557
+# ---
+# name: TestOscillator.test_constant_snapshot.30
+  0.5667135704060806
+# ---
+# name: TestOscillator.test_constant_snapshot.31
+  0.13067344365924494
+# ---
+# name: TestOscillator.test_constant_snapshot.32
+  -0.6321720124467993
+# ---
+# name: TestOscillator.test_constant_snapshot.33
+  2.8029394711714257
+# ---
+# name: TestOscillator.test_constant_snapshot.34
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.35
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.36
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.876122286854548,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.12387771314545182,
+    'state_of_interest': 0.12387771314545182,
+  })
+# ---
+# name: TestOscillator.test_constant_snapshot.37
+  0.13521198455357342
+# ---
+# name: TestOscillator.test_constant_snapshot.38
+  0.24856720024803347
+# ---
+# name: TestOscillator.test_constant_snapshot.39
+  0.11803000341030895
+# ---
+# name: TestOscillator.test_constant_snapshot.4
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8904175805776147,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10958241942238534,
+    'state_of_interest': 0.10958241942238534,
+  })
+# ---
+# name: TestOscillator.test_constant_snapshot.40
+  -0.12071230469371952
+# ---
+# name: TestOscillator.test_constant_snapshot.41
+  2.286834996999153
+# ---
+# name: TestOscillator.test_constant_snapshot.42
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.43
+  False
+# ---
+# name: TestOscillator.test_constant_snapshot.44
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8647880154464267,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.13521198455357342,
+    'state_of_interest': 0.13521198455357342,
+  })
+# ---
+# name: TestOscillator.test_constant_snapshot.5
+  0.10909344694040175
+# ---
+# name: TestOscillator.test_constant_snapshot.6
+  0.18702638089196827
+# ---
+# name: TestOscillator.test_constant_snapshot.7
+  0.14501811219702787
+# ---
+# name: TestOscillator.test_constant_snapshot.8
+  -0.19298094228082074
+# ---
+# name: TestOscillator.test_constant_snapshot.9
+  3.4520313962115345
+# ---
 # name: TestOscillator.test_reset
-  3.8697803020477295
+  3.8697802427798167
 # ---
 # name: TestOscillator.test_reset.1
-  2.194392204284668
+  2.1943921987602617
 # ---
 # name: TestOscillator.test_reset.2
-  4.292989730834961
+  4.292989599556912
 # ---
 # name: TestOscillator.test_reset.3
-  3.48684024810791
+  3.4868401452968194
 # ---
 # name: TestOscillator.test_reset.4
-  0.4708867371082306
+  0.47088673943824766
 # ---
 # name: TestOscillator.test_reset.5
-  4.878111839294434
+  4.878111758183779
 # ---
 # name: TestOscillator.test_reset.6
   8.0
 # ---
 # name: TestOscillator.test_reset.7
-  -4.51315975189209
+  -4.513159854703181
 # ---
 # name: TestOscillator.test_reset.8
   dict({
@@ -34,10 +211,10 @@
   })
 # ---
 # name: TestOscillator.test_step
-  6.0547027587890625
+  6.054702492845994
 # ---
 # name: TestOscillator.test_step.1
-  1.3536723852157593
+  1.3536723708128777
 # ---
 # name: TestOscillator.test_step.10
   False
@@ -53,34 +230,34 @@
   })
 # ---
 # name: TestOscillator.test_step.12
-  7.115191459655762
+  7.115191374657359
 # ---
 # name: TestOscillator.test_step.13
   0.0
 # ---
 # name: TestOscillator.test_step.14
-  12.879240036010742
+  12.87923968774058
 # ---
 # name: TestOscillator.test_step.15
-  4.631739139556885
+  4.631739299753713
 # ---
 # name: TestOscillator.test_step.16
-  0.9626997113227844
+  0.9626996889912394
 # ---
 # name: TestOscillator.test_step.17
-  6.316237926483154
+  6.316237850683443
 # ---
 # name: TestOscillator.test_step.18
-  8.439533233642578
+  8.439533636705194
 # ---
 # name: TestOscillator.test_step.19
-  -3.8077943325042725
+  -3.8077943369514813
 # ---
 # name: TestOscillator.test_step.2
-  8.501704216003418
+  8.5017041586181
 # ---
 # name: TestOscillator.test_step.20
-  14.499297568084557
+  14.499297712519772
 # ---
 # name: TestOscillator.test_step.21
   False
@@ -91,42 +268,42 @@
 # name: TestOscillator.test_step.23
   dict({
     'reference': 8.439533636705194,
-    'reference_constraint_error': -15.368260681280555,
+    'reference_constraint_error': -15.368260700246287,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -3.807794317985749,
-    'state_of_interest': 4.631739318719445,
+    'reference_error': -3.8077943369514813,
+    'state_of_interest': 4.631739299753713,
   })
 # ---
 # name: TestOscillator.test_step.24
-  8.62728214263916
+  8.62728249535218
 # ---
 # name: TestOscillator.test_step.25
-  2.931903123855591
+  2.931902989654285
 # ---
 # name: TestOscillator.test_step.26
-  7.930094242095947
+  7.930094036684647
 # ---
 # name: TestOscillator.test_step.27
-  5.492265701293945
+  5.492265561713667
 # ---
 # name: TestOscillator.test_step.28
-  0.9049376845359802
+  0.904937707651765
 # ---
 # name: TestOscillator.test_step.29
-  7.997941970825195
+  7.997941929680929
 # ---
 # name: TestOscillator.test_step.3
-  3.896794557571411
+  3.896794575423781
 # ---
 # name: TestOscillator.test_step.30
-  8.658758163452148
+  8.6587581932296
 # ---
 # name: TestOscillator.test_step.31
-  -3.1664927005767822
+  -3.1664926315159327
 # ---
 # name: TestOscillator.test_step.32
-  10.026675404881283
+  10.026675585444696
 # ---
 # name: TestOscillator.test_step.33
   False
@@ -137,42 +314,42 @@
 # name: TestOscillator.test_step.35
   dict({
     'reference': 8.6587581932296,
-    'reference_constraint_error': -14.507734409774752,
+    'reference_constraint_error': -14.507734438286333,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -3.166492603004353,
-    'state_of_interest': 5.492265590225247,
+    'reference_error': -3.1664926315159327,
+    'state_of_interest': 5.492265561713667,
   })
 # ---
 # name: TestOscillator.test_step.36
-  6.775404453277588
+  6.77540453458308
 # ---
 # name: TestOscillator.test_step.37
-  1.2221184968948364
+  1.2221184287656546
 # ---
 # name: TestOscillator.test_step.38
-  11.808575630187988
+  11.808575489982447
 # ---
 # name: TestOscillator.test_step.39
-  6.543094635009766
+  6.543094827267196
 # ---
 # name: TestOscillator.test_step.4
-  0.7937362790107727
+  0.7937362868735947
 # ---
 # name: TestOscillator.test_step.40
-  1.3197458982467651
+  1.3197459235373448
 # ---
 # name: TestOscillator.test_step.41
-  8.786880493164062
+  8.786880459769616
 # ---
 # name: TestOscillator.test_step.42
-  8.87733268737793
+  8.877332634950129
 # ---
 # name: TestOscillator.test_step.43
-  -2.334237813949585
+  -2.334237807682933
 # ---
 # name: TestOscillator.test_step.44
-  5.448665969810497
+  5.448666142816425
 # ---
 # name: TestOscillator.test_step.45
   False
@@ -183,42 +360,42 @@
 # name: TestOscillator.test_step.47
   dict({
     'reference': 8.877332634950129,
-    'reference_constraint_error': -13.45690513567447,
+    'reference_constraint_error': -13.456905172732803,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -2.3342377706245987,
-    'state_of_interest': 6.54309486432553,
+    'reference_error': -2.334237807682933,
+    'state_of_interest': 6.543094827267196,
   })
 # ---
 # name: TestOscillator.test_step.48
-  7.150448799133301
+  7.1504489432514395
 # ---
 # name: TestOscillator.test_step.49
-  4.290715217590332
+  4.2907152128944634
 # ---
 # name: TestOscillator.test_step.5
-  5.272303581237793
+  5.272303388621858
 # ---
 # name: TestOscillator.test_step.50
-  9.936918258666992
+  9.936918693702047
 # ---
 # name: TestOscillator.test_step.51
-  7.234573841094971
+  7.234573863164457
 # ---
 # name: TestOscillator.test_step.52
-  1.4361001253128052
+  1.4361001167276088
 # ---
 # name: TestOscillator.test_step.53
-  10.149039268493652
+  10.149039710580631
 # ---
 # name: TestOscillator.test_step.54
-  9.095041275024414
+  9.095041255281616
 # ---
 # name: TestOscillator.test_step.55
-  -1.8604673147201538
+  -1.860467392117159
 # ---
 # name: TestOscillator.test_step.56
-  3.4613387603390935
+  3.461338917131223
 # ---
 # name: TestOscillator.test_step.57
   False
@@ -229,18 +406,18 @@
 # name: TestOscillator.test_step.59
   dict({
     'reference': 9.095041255281616,
-    'reference_constraint_error': -12.765426094697709,
+    'reference_constraint_error': -12.765426136835544,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -1.8604673499793254,
-    'state_of_interest': 7.234573905302291,
+    'reference_error': -1.860467392117159,
+    'state_of_interest': 7.234573863164457,
   })
 # ---
 # name: TestOscillator.test_step.6
-  8.21987533569336
+  8.219875313546899
 # ---
 # name: TestOscillator.test_step.7
-  -4.323080539703369
+  -4.323080738123117
 # ---
 # name: TestOscillator.test_step.8
   18.689027068331118

--- a/tests/__snapshots__/test_oscillator_complicated.ambr
+++ b/tests/__snapshots__/test_oscillator_complicated.ambr
@@ -1,9 +1,186 @@
 # serializer version: 1
+# name: TestOscillatorComplicated.test_constant_snapshot
+  0.10958241942238534
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.1
+  -0.024448624099179084
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.10
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.11
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.12
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8909065530595983,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10909344694040175,
+    'state_of_interest': 0.10909344694040175,
+  })
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.13
+  0.11283397455824112
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.14
+  0.1373521677359711
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.15
+  0.14115849335141145
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.16
+  -0.07676570293056856
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.17
+  3.270741362539796
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.18
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.19
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.2
+  0.14343916796455297
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.20
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.887166025441759,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11283397455824112,
+    'state_of_interest': 0.11283397455824112,
+  })
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.21
+  0.11558101791296055
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.22
+  0.41483476162456334
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.23
+  0.13962317929280008
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.24
+  -0.44748678167775646
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.25
+  3.199988707897624
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.26
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.27
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.28
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8844189820870394,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.11558101791296055,
+    'state_of_interest': 0.11558101791296055,
+  })
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.29
+  0.12387771314545182
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.3
+  0.07894721162374557
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.30
+  0.5667135704060806
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.31
+  0.13067344365924494
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.32
+  -0.6321720124467993
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.33
+  2.8029394711714257
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.34
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.35
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.36
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.876122286854548,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.12387771314545182,
+    'state_of_interest': 0.12387771314545182,
+  })
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.37
+  0.13521198455357342
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.38
+  0.24856720024803347
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.39
+  0.11803000341030895
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.4
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8904175805776147,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.10958241942238534,
+    'state_of_interest': 0.10958241942238534,
+  })
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.40
+  -0.12071230469371952
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.41
+  2.286834996999153
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.42
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.43
+  False
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.44
+  dict({
+    'reference': 0.0,
+    'reference_constraint_error': -3.8647880154464267,
+    'reference_constraint_position': 4.0,
+    'reference_constraint_violated': False,
+    'reference_error': 0.13521198455357342,
+    'state_of_interest': 0.13521198455357342,
+  })
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.5
+  0.10909344694040175
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.6
+  0.18702638089196827
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.7
+  0.14501811219702787
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.8
+  -0.19298094228082074
+# ---
+# name: TestOscillatorComplicated.test_constant_snapshot.9
+  3.4520313962115345
+# ---
 # name: TestOscillatorComplicated.test_reset
-  3.8697803020477295
+  3.8697802427798167
 # ---
 # name: TestOscillatorComplicated.test_reset.1
-  2.194392204284668
+  2.1943921987602617
 # ---
 # name: TestOscillatorComplicated.test_reset.10
   dict({
@@ -16,34 +193,34 @@
   })
 # ---
 # name: TestOscillatorComplicated.test_reset.2
-  4.292989730834961
+  4.292989599556912
 # ---
 # name: TestOscillatorComplicated.test_reset.3
-  3.48684024810791
+  3.4868401452968194
 # ---
 # name: TestOscillatorComplicated.test_reset.4
-  0.4708867371082306
+  0.47088673943824766
 # ---
 # name: TestOscillatorComplicated.test_reset.5
-  4.878111839294434
+  4.878111758183779
 # ---
 # name: TestOscillatorComplicated.test_reset.6
-  3.8056983947753906
+  3.805698509951765
 # ---
 # name: TestOscillatorComplicated.test_reset.7
-  3.930321455001831
+  3.930321526384769
 # ---
 # name: TestOscillatorComplicated.test_reset.8
   8.0
 # ---
 # name: TestOscillatorComplicated.test_reset.9
-  -7.529113292694092
+  -7.529113260561752
 # ---
 # name: TestOscillatorComplicated.test_step
-  6.087455749511719
+  6.087455541244575
 # ---
 # name: TestOscillatorComplicated.test_step.1
-  2.541687488555908
+  2.541687540355613
 # ---
 # name: TestOscillatorComplicated.test_step.10
   51.2380654736653
@@ -65,40 +242,40 @@
   })
 # ---
 # name: TestOscillatorComplicated.test_step.14
-  1.1390810012817383
+  1.139080931751879
 # ---
 # name: TestOscillatorComplicated.test_step.15
-  7.643327236175537
+  7.643327224435085
 # ---
 # name: TestOscillatorComplicated.test_step.16
-  8.770023345947266
+  8.770023692875586
 # ---
 # name: TestOscillatorComplicated.test_step.17
-  7.1490559577941895
+  7.149056015353484
 # ---
 # name: TestOscillatorComplicated.test_step.18
-  1.972083330154419
+  1.972083358080852
 # ---
 # name: TestOscillatorComplicated.test_step.19
-  5.047006130218506
+  5.047006142681629
 # ---
 # name: TestOscillatorComplicated.test_step.2
-  7.256617069244385
+  7.256617066092945
 # ---
 # name: TestOscillatorComplicated.test_step.20
-  5.169439792633057
+  5.169439569741611
 # ---
 # name: TestOscillatorComplicated.test_step.21
-  4.798206806182861
+  4.798206919670843
 # ---
 # name: TestOscillatorComplicated.test_step.22
-  8.439533233642578
+  8.439533636705194
 # ---
 # name: TestOscillatorComplicated.test_step.23
-  -6.467450141906738
+  -6.467450278624343
 # ---
 # name: TestOscillatorComplicated.test_step.24
-  41.82791286115823
+  41.827913106478086
 # ---
 # name: TestOscillatorComplicated.test_step.25
   False
@@ -109,54 +286,54 @@
 # name: TestOscillatorComplicated.test_step.27
   dict({
     'reference': 8.439533636705194,
-    'reference_constraint_error': -18.027916622953416,
+    'reference_constraint_error': -18.02791664191915,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -6.4674502596586105,
-    'state_of_interest': 1.9720833770465842,
+    'reference_error': -6.467450278624343,
+    'state_of_interest': 1.972083358080852,
   })
 # ---
 # name: TestOscillatorComplicated.test_step.28
   0.0
 # ---
 # name: TestOscillatorComplicated.test_step.29
-  6.251512050628662
+  6.251511988275885
 # ---
 # name: TestOscillatorComplicated.test_step.3
-  5.00596284866333
+  5.005962881903876
 # ---
 # name: TestOscillatorComplicated.test_step.30
-  6.1352410316467285
+  6.135240746499774
 # ---
 # name: TestOscillatorComplicated.test_step.31
-  10.330570220947266
+  10.330570533462584
 # ---
 # name: TestOscillatorComplicated.test_step.32
-  2.036011219024658
+  2.0360113056763014
 # ---
 # name: TestOscillatorComplicated.test_step.33
-  5.967118263244629
+  5.967118130030345
 # ---
 # name: TestOscillatorComplicated.test_step.34
-  6.262476921081543
+  6.262476986417208
 # ---
 # name: TestOscillatorComplicated.test_step.35
-  5.654163360595703
+  5.65416346694715
 # ---
 # name: TestOscillatorComplicated.test_step.36
-  8.658758163452148
+  8.6587581932296
 # ---
 # name: TestOscillatorComplicated.test_step.37
-  -6.62274694442749
+  -6.622746887553299
 # ---
 # name: TestOscillatorComplicated.test_step.38
-  43.86077602563702
+  43.860776336596906
 # ---
 # name: TestOscillatorComplicated.test_step.39
   False
 # ---
 # name: TestOscillatorComplicated.test_step.4
-  1.061798334121704
+  1.0617983739167234
 # ---
 # name: TestOscillatorComplicated.test_step.40
   False
@@ -164,48 +341,48 @@
 # name: TestOscillatorComplicated.test_step.41
   dict({
     'reference': 8.6587581932296,
-    'reference_constraint_error': -17.963988670847044,
+    'reference_constraint_error': -17.9639886943237,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -6.622746864076644,
-    'state_of_interest': 2.0360113291529562,
+    'reference_error': -6.622746887553299,
+    'state_of_interest': 2.0360113056763014,
   })
 # ---
 # name: TestOscillatorComplicated.test_step.42
-  1.4871808290481567
+  1.4871808075434318
 # ---
 # name: TestOscillatorComplicated.test_step.43
-  8.789847373962402
+  8.789847065819913
 # ---
 # name: TestOscillatorComplicated.test_step.44
-  4.631452560424805
+  4.63145230142228
 # ---
 # name: TestOscillatorComplicated.test_step.45
-  5.989849090576172
+  5.989849036301869
 # ---
 # name: TestOscillatorComplicated.test_step.46
-  1.9138506650924683
+  1.9138506273357234
 # ---
 # name: TestOscillatorComplicated.test_step.47
-  6.609333038330078
+  6.609332960352666
 # ---
 # name: TestOscillatorComplicated.test_step.48
-  6.868366718292236
+  6.868366886672139
 # ---
 # name: TestOscillatorComplicated.test_step.49
-  6.967804908752441
+  6.967804944284334
 # ---
 # name: TestOscillatorComplicated.test_step.5
-  4.936527729034424
+  4.9365278044943945
 # ---
 # name: TestOscillatorComplicated.test_step.50
-  8.87733268737793
+  8.877332634950129
 # ---
 # name: TestOscillatorComplicated.test_step.51
-  -6.963481903076172
+  -6.963482007614406
 # ---
 # name: TestOscillatorComplicated.test_step.52
-  48.49008136302854
+  48.490081670369555
 # ---
 # name: TestOscillatorComplicated.test_step.53
   False
@@ -216,48 +393,48 @@
 # name: TestOscillatorComplicated.test_step.55
   dict({
     'reference': 8.877332634950129,
-    'reference_constraint_error': -18.086149350596223,
+    'reference_constraint_error': -18.086149372664277,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -6.96348198554635,
-    'state_of_interest': 1.9138506494037788,
+    'reference_error': -6.963482007614406,
+    'state_of_interest': 1.9138506273357234,
   })
 # ---
 # name: TestOscillatorComplicated.test_step.56
-  1.8273701667785645
+  1.8273701647910303
 # ---
 # name: TestOscillatorComplicated.test_step.57
-  3.364783763885498
+  3.3647837737494335
 # ---
 # name: TestOscillatorComplicated.test_step.58
-  7.202538967132568
+  7.202539228614338
 # ---
 # name: TestOscillatorComplicated.test_step.59
-  6.381329536437988
+  6.381329798471056
 # ---
 # name: TestOscillatorComplicated.test_step.6
-  4.264235019683838
+  4.264234935283765
 # ---
 # name: TestOscillatorComplicated.test_step.60
-  2.036968469619751
+  2.0369685189025293
 # ---
 # name: TestOscillatorComplicated.test_step.61
-  7.6191487312316895
+  7.619148513262692
 # ---
 # name: TestOscillatorComplicated.test_step.62
-  7.197297096252441
+  7.197297241699376
 # ---
 # name: TestOscillatorComplicated.test_step.63
-  7.50811243057251
+  7.508112493435574
 # ---
 # name: TestOscillatorComplicated.test_step.64
-  9.095041275024414
+  9.095041255281616
 # ---
 # name: TestOscillatorComplicated.test_step.65
-  -7.058072566986084
+  -7.058072736379087
 # ---
 # name: TestOscillatorComplicated.test_step.66
-  49.81639045195799
+  49.81639075201777
 # ---
 # name: TestOscillatorComplicated.test_step.67
   False
@@ -268,19 +445,19 @@
 # name: TestOscillatorComplicated.test_step.69
   dict({
     'reference': 9.095041255281616,
-    'reference_constraint_error': -17.963031459840977,
+    'reference_constraint_error': -17.96303148109747,
     'reference_constraint_position': 20.0,
     'reference_constraint_violated': False,
-    'reference_error': -7.0580727151225915,
-    'state_of_interest': 2.036968540159025,
+    'reference_error': -7.058072736379087,
+    'state_of_interest': 2.0369685189025293,
   })
 # ---
 # name: TestOscillatorComplicated.test_step.7
-  4.252396583557129
+  4.252396658049173
 # ---
 # name: TestOscillatorComplicated.test_step.8
-  8.21987533569336
+  8.219875313546899
 # ---
 # name: TestOscillatorComplicated.test_step.9
-  -7.158076763153076
+  -7.158076939630176
 # ---

--- a/tests/test_cart_pole.py
+++ b/tests/test_cart_pole.py
@@ -23,8 +23,8 @@ class TestCartPoleCostEqual:
     env_cost.unwrapped.force_mag = 10.0
     env_cost.unwrapped.theta_threshold_radians = 12 * 2 * math.pi / 360
     env_cost.unwrapped.x_threshold = 2.4
-    env_cost.unwrapped.max_v = np.finfo(np.float32).max
-    env_cost.unwrapped.max_x = np.finfo(np.float32).max
+    env_cost.unwrapped.max_v = np.finfo(np.float64).max
+    env_cost.unwrapped.max_x = np.finfo(np.float64).max
     env_cost.unwrapped._init_state_range = {
         "low": [-0.05, -0.05, -0.05, -0.05],
         "high": [0.05, 0.05, 0.05, 0.05],
@@ -46,9 +46,7 @@ class TestCartPoleCostEqual:
         for _ in range(10):
             discrete_action = random.randint(0, 1)
             continuous_action = (
-                np.array([-10], dtype=np.float32)
-                if discrete_action == 0
-                else np.array([10], dtype=np.float32)
+                np.array([-10]) if discrete_action == 0 else np.array([10])
             )
             observation, _, _, _, _ = self.env.step(discrete_action)
             observation_cost, _, _, _, _ = self.env_cost.step(continuous_action)
@@ -57,7 +55,7 @@ class TestCartPoleCostEqual:
             ), f"{observation} != {observation_cost}"
 
     def test_snapshot(self, snapshot):
-        """Test if the 'CartPoleCost' environment is still equal snapshot."""
+        """Test if the 'CartPoleCost' environment is still equal to snapshot."""
         observation, info = self.env_cost.reset(seed=42)
         assert (observation == snapshot).all()
         assert info == snapshot
@@ -67,6 +65,63 @@ class TestCartPoleCostEqual:
             observation, reward, terminated, truncated, info = self.env_cost.step(
                 action
             )
+            assert (observation == snapshot).all()
+            assert reward == snapshot
+            assert terminated == snapshot
+            assert truncated == snapshot
+            assert info == snapshot
+
+    def test_reference_tracking_snapshot(self, snapshot):
+        """Test if the 'CartPoleCost' environment with a 'reference_tracking' task is
+        still equal to snapshot.
+        """
+        env_cost_reference_tracking = gym.make(
+            "CartPoleCost",
+            task_type="reference_tracking",
+            exclude_reference_error_from_observation=False,
+        )
+        observation, info = env_cost_reference_tracking.reset(seed=42)
+        assert (observation == snapshot).all()
+        assert info == snapshot
+        env_cost_reference_tracking.action_space.seed(42)
+        for _ in range(5):
+            action = env_cost_reference_tracking.action_space.sample()
+            (
+                observation,
+                reward,
+                terminated,
+                truncated,
+                info,
+            ) = env_cost_reference_tracking.step(action)
+            assert (observation == snapshot).all()
+            assert reward == snapshot
+            assert terminated == snapshot
+            assert truncated == snapshot
+            assert info == snapshot
+
+    def test_reference_tracking_periodic_snapshot(self, snapshot):
+        """Test if the 'CartPoleCost' environment with a 'reference_tracking' task and
+        a 'periodic' reference is still equal to snapshot.
+        """
+        env_cost_reference_tracking_periodic = gym.make(
+            "CartPoleCost",
+            task_type="reference_tracking",
+            reference_type="periodic",
+            exclude_reference_error_from_observation=False,
+        )
+        observation, info = env_cost_reference_tracking_periodic.reset(seed=42)
+        assert (observation == snapshot).all()
+        assert info == snapshot
+        env_cost_reference_tracking_periodic.action_space.seed(42)
+        for _ in range(5):
+            action = env_cost_reference_tracking_periodic.action_space.sample()
+            (
+                observation,
+                reward,
+                terminated,
+                truncated,
+                info,
+            ) = env_cost_reference_tracking_periodic.step(action)
             assert (observation == snapshot).all()
             assert reward == snapshot
             assert terminated == snapshot

--- a/tests/test_oscillator.py
+++ b/tests/test_oscillator.py
@@ -10,7 +10,7 @@ gym.logger.set_level(ERROR)
 
 
 class TestOscillator:
-    env = gym.make("Oscillator")
+    env = gym.make("Oscillator", exclude_reference_error_from_observation=False)
 
     def test_reset(self, snapshot):
         """Test if reset is still equal to the last snapshot."""
@@ -25,6 +25,33 @@ class TestOscillator:
         for _ in range(5):
             action = self.env.action_space.sample()
             observation, reward, terminated, truncated, info = self.env.step(action)
+            assert (observation == snapshot).all()
+            assert reward == snapshot
+            assert terminated == snapshot
+            assert truncated == snapshot
+            assert info == snapshot
+
+    def test_constant_snapshot(self, snapshot):
+        """Test if the 'CartPoleCost' environment with 'constant' reference is still
+        equal to snapshot.
+        """
+        env_cost_reference_tracking = gym.make(
+            "CartPoleCost",
+            reference_type="constant",
+        )
+        observation, info = env_cost_reference_tracking.reset(seed=42)
+        assert (observation == snapshot).all()
+        assert info == snapshot
+        env_cost_reference_tracking.action_space.seed(42)
+        for _ in range(5):
+            action = env_cost_reference_tracking.action_space.sample()
+            (
+                observation,
+                reward,
+                terminated,
+                truncated,
+                info,
+            ) = env_cost_reference_tracking.step(action)
             assert (observation == snapshot).all()
             assert reward == snapshot
             assert terminated == snapshot

--- a/tests/test_oscillator_complicated.py
+++ b/tests/test_oscillator_complicated.py
@@ -10,7 +10,9 @@ gym.logger.set_level(ERROR)
 
 
 class TestOscillatorComplicated:
-    env = gym.make("OscillatorComplicated")
+    env = gym.make(
+        "OscillatorComplicated", exclude_reference_error_from_observation=False
+    )
 
     def test_reset(self, snapshot):
         """Test if reset is still equal to the last snapshot."""
@@ -25,6 +27,33 @@ class TestOscillatorComplicated:
         for _ in range(5):
             action = self.env.action_space.sample()
             observation, reward, terminated, truncated, info = self.env.step(action)
+            assert (observation == snapshot).all()
+            assert reward == snapshot
+            assert terminated == snapshot
+            assert truncated == snapshot
+            assert info == snapshot
+
+    def test_constant_snapshot(self, snapshot):
+        """Test if the 'CartPoleCost' environment with 'constant' reference is still
+        equal to snapshot.
+        """
+        env_cost_reference_tracking = gym.make(
+            "CartPoleCost",
+            reference_type="constant",
+        )
+        observation, info = env_cost_reference_tracking.reset(seed=42)
+        assert (observation == snapshot).all()
+        assert info == snapshot
+        env_cost_reference_tracking.action_space.seed(42)
+        for _ in range(5):
+            action = env_cost_reference_tracking.action_space.sample()
+            (
+                observation,
+                reward,
+                terminated,
+                truncated,
+                info,
+            ) = env_cost_reference_tracking.step(action)
             assert (observation == snapshot).all()
             assert reward == snapshot
             assert terminated == snapshot


### PR DESCRIPTION
This pull request ensures the `cost_range` is renamed to `reward_range`. This is done since this is the
variable used in the Gymnasium package. Additionally, the observation/action and reward space
accuracy was increased to float64.
