### PR TITLE
feat: add 'MinitaurCost' environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
     "gymnasium-robotics>=1.2.2",
     "matplotlib>=3.7.1",
     "iteration_utilities>=0.11.0",
-    "mujoco==2.3.3" # TODO: Remove when https://github.com/Farama-Foundation/Gymnasium/issues/597 is resolved.
+    "mujoco==2.3.3", # TODO: Remove when https://github.com/Farama-Foundation/Gymnasium/issues/597 is resolved.
+    "pybullet>=3.2.5",
 ]
 requires-python = ">=3.8"
 
@@ -46,12 +47,13 @@ dev = [
     "syrupy>=4.0.2",
     "flake8>=6.0.0",
     "black>=23.3.0",
+    "gym==0.25.1", # TODO: Can be removed when https://github.com/bulletphysics/bullet3/issues/4369 is resoled. # noqa: E501
 ]
 docs = [
     "sphinx>=6.2.1",
     "sphinx_rtd_theme>=1.2.2",
     "myst-parser>=1.0.0",
-    "sphinx-autoapi>=2.1.1"
+    "sphinx-autoapi>=2.1.1",
 ]
 
 [project.urls]

--- a/stable_gym/__init__.py
+++ b/stable_gym/__init__.py
@@ -1,75 +1,84 @@
-"""Module that register the Stable Gym gymnasium environments."""
+"""Entry_point that register the Stable Gym gymnasium environments."""
 import gymnasium as gym
 from gymnasium.envs.registration import register
 
-# Make module version available.
+# Make entry_point version available.
 from .version import __version__, __version_tuple__
 
 # Available environments.
 # TODO: Update reward thresholds.
 ENVS = {
     "Oscillator-v1": {
-        "module": "stable_gym.envs.biological.oscillator.oscillator:Oscillator",
-        "max_step": 400,
+        "entry_point": "stable_gym.envs.biological.oscillator.oscillator:Oscillator",
         "reward_threshold": 300,
+        "max_episode_steps": 400,
     },
     "OscillatorComplicated-v1": {
-        "module": "stable_gym.envs.biological.oscillator_complicated.oscillator_complicated:OscillatorComplicated",
-        "max_step": 400,
+        "entry_point": "stable_gym.envs.biological.oscillator_complicated.oscillator_complicated:OscillatorComplicated",
         "reward_threshold": 300,
+        "max_episode_steps": 400,
     },
     "CartPoleCost-v1": {
-        "module": "stable_gym.envs.classic_control.cartpole_cost.cartpole_cost:CartPoleCost",
-        "max_step": 250,
+        "entry_point": "stable_gym.envs.classic_control.cartpole_cost.cartpole_cost:CartPoleCost",
         "reward_threshold": 300,
+        "max_episode_steps": 250,
     },
     "Ex3EKF-v1": {
-        "module": "stable_gym.envs.classic_control.ex3_ekf.ex3_ekf:Ex3EKF",
-        "max_step": 400,
+        "entry_point": "stable_gym.envs.classic_control.ex3_ekf.ex3_ekf:Ex3EKF",
         "reward_threshold": 300,
+        "max_episode_steps": 400,
     },
     "AntCost-v1": {
-        "module": "stable_gym.envs.mujoco.ant_cost.ant_cost:AntCost",
-        "max_step": 250,
+        "entry_point": "stable_gym.envs.mujoco.ant_cost.ant_cost:AntCost",
         "reward_threshold": 300,
+        "max_episode_steps": 250,
     },
     "HalfCheetahCost-v1": {
-        "module": "stable_gym.envs.mujoco.half_cheetah_cost.half_cheetah_cost:HalfCheetahCost",
-        "max_step": 200,
+        "entry_point": "stable_gym.envs.mujoco.half_cheetah_cost.half_cheetah_cost:HalfCheetahCost",
         "reward_threshold": 300,
+        "max_episode_steps": 200,
     },
     "HopperCost-v1": {
-        "module": "stable_gym.envs.mujoco.hopper_cost.hopper_cost:HopperCost",
-        "max_step": 250,
+        "entry_point": "stable_gym.envs.mujoco.hopper_cost.hopper_cost:HopperCost",
         "reward_threshold": 300,
+        "max_episode_steps": 250,
     },
     "HumanoidCost-v1": {
-        "module": "stable_gym.envs.mujoco.humanoid_cost.humanoid_cost:HumanoidCost",
-        "max_step": 250,
+        "entry_point": "stable_gym.envs.mujoco.humanoid_cost.humanoid_cost:HumanoidCost",
         "reward_threshold": 300,
+        "max_episode_steps": 250,
     },
     "SwimmerCost-v1": {
-        "module": "stable_gym.envs.mujoco.swimmer_cost.swimmer_cost:SwimmerCost",
-        "max_step": 250,
+        "entry_point": "stable_gym.envs.mujoco.swimmer_cost.swimmer_cost:SwimmerCost",
         "reward_threshold": 300,
+        "max_episode_steps": 250,
     },
     "Walker2dCost-v1": {
-        "module": "stable_gym.envs.mujoco.walker2d_cost.walker2d_cost:Walker2dCost",
-        "max_step": 250,
+        "entry_point": "stable_gym.envs.mujoco.walker2d_cost.walker2d_cost:Walker2dCost",
         "reward_threshold": 300,
+        "max_episode_steps": 250,
     },
     "FetchReachCost-v1": {
-        "module": "stable_gym.envs.robotics.fetch.fetch_reach_cost.fetch_reach_cost:FetchReachCost",
-        "max_step": 50,
+        "entry_point": "stable_gym.envs.robotics.fetch.fetch_reach_cost.fetch_reach_cost:FetchReachCost",
         "reward_threshold": 300,
+        "max_episode_steps": 50,
+    },
+    # NOTE: The Minitaur environment is not compatible with gymnasium. See
+    # https://github.com/bulletphysics/bullet3/issues/4369 for more details.
+    "MinitaurCost-v1": {
+        "entry_point": "stable_gym.envs.robotics.minitaur_cost.minitaur_cost:MinitaurCost",
+        "reward_threshold": 300,
+        "max_episode_steps": 500,
+        "compatible": False,
     },
 }
 
 for env, val in ENVS.items():
-    if env not in gym.envs.registry:  # NOTE: Required because we use namespace packages
-        register(
-            id=env,
-            entry_point=val["module"],
-            max_episode_steps=val["max_step"],
-            reward_threshold=val["reward_threshold"],
-        )
+    register(
+        id=env,
+        entry_point=val["entry_point"],
+        reward_threshold=val["reward_threshold"],
+        max_episode_steps=val["max_episode_steps"],
+        disable_env_checker=not val["compatible"] if "compatible" in val else False,
+        apply_api_compatibility=not val["compatible"] if "compatible" in val else False,
+    )

--- a/stable_gym/common/utils.py
+++ b/stable_gym/common/utils.py
@@ -2,6 +2,7 @@
 import re
 
 import numpy as np
+import gymnasium as gym
 from gymnasium.utils import colorize as gym_colorize
 
 
@@ -289,3 +290,35 @@ def maybe_parse_reset_bounds(options, default_low, default_high):
         )
 
     return low, high
+
+
+def change_dict_key(d, old_key, new_key, default_value=None):
+    """Changes the key of a dictionary.
+
+    Args:
+        d (dict): The dictionary.
+        old_key (str): The old key.
+        new_key (str): The new key.
+        default_value (any, optional): The default value to use if the old key is not
+            present in the dictionary. Defaults to ``None``.
+    """
+    d[new_key] = d.pop(old_key, default_value)
+    return d
+
+
+def convert_gym_box_to_gymnasium_box(gym_box_space):
+    """Converts a gym box space to a gymnasium box space.
+
+    Args:
+        gym_box_space (gym.spaces.Box): The gym box space.
+
+    Returns:
+        gymnasium.spaces.Box: The gymnasium box space.
+    """
+    return gym.spaces.Box(
+        low=gym_box_space.low,
+        high=gym_box_space.high,
+        shape=gym_box_space.shape,
+        dtype=gym_box_space.dtype,
+        seed=gym_box_space.np_random,
+    )

--- a/stable_gym/envs/mujoco/ant_cost/README.md
+++ b/stable_gym/envs/mujoco/ant_cost/README.md
@@ -7,10 +7,9 @@
 
 An actuated 8-jointed ant. This environment corresponds to the [Ant-v4](https://gymnasium.farama.org/environments/mujoco/ant) environment included in the [gymnasium package](https://gymnasium.farama.org/). It is different in the fact that:
 
-*   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost. This cost is the squared
-    difference between the Ant's forward velocity and a reference value (error).
+*   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the Ant's forward velocity and a reference value (error).
 *   Three **optional** variables were added to the observation space; The reference velocity, the reference error (i.e. the difference between the ant's forward velocity and the reference) and the ant's forward velocity. These variables can be enabled using the `exclude_reference_from_observation`, `exclude_reference_error_from_observation` and `exclude_velocity_from_observation` environment arguments.
-    
+
 The rest of the environment is the same as the original Ant environment. Below, the modified cost is described. For more information about the environment (e.g. observation space, action space, episode termination, etc.), please refer to the [gymnasium library](https://gymnasium.farama.org/environments/mujoco/ant/).
 
 ## Cost function

--- a/stable_gym/envs/mujoco/swimmer_cost/README.md
+++ b/stable_gym/envs/mujoco/swimmer_cost/README.md
@@ -8,7 +8,7 @@
 An actuated 2-jointed swimmer. This environment corresponds to the [Swimmer-v4](https://gymnasium.farama.org/environments/mujoco/swimmer) environment included in the [gymnasium package](https://gymnasium.farama.org/). It is different in the fact that:
 
 *   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the Swimmer's forward velocity and a reference value (error).
--   Three **optional** variables were added to the observation space; The reference velocity, the reference error (i.e. the difference between the swimmer's forward velocity and the reference) and the swimmer's forward velocity. These variables can be enabled using the `exclude_reference_from_observation`, `exclude_reference_error_from_observation` and `exclude_velocity_from_observation` environment arguments.
+*   Three **optional** variables were added to the observation space; The reference velocity, the reference error (i.e. the difference between the swimmer's forward velocity and the reference) and the swimmer's forward velocity. These variables can be enabled using the `exclude_reference_from_observation`, `exclude_reference_error_from_observation` and `exclude_velocity_from_observation` environment arguments.
 
 The rest of the environment is the same as the original Swimmer environment. Below, the modified cost is described. For more information about the environment (e.g. observation space, action space, episode termination, etc.), please refer to the [gymnasium library](https://gymnasium.farama.org/environments/mujoco/swimmer/).
 

--- a/stable_gym/envs/robotics/__init__.py
+++ b/stable_gym/envs/robotics/__init__.py
@@ -1,5 +1,5 @@
-"""Stable Gym gymnasium environments that are based on the environments found in the
-:gymnasium-robotics:`Gymnasium Robotics <>` package.
+"""Stable Gym gymnasium environments that are based on robotics environments found in
+the :gymnasium-robotics:`Gymnasium Robotics <>` and `Pybullet`_ packages.
 
 .. note::
 
@@ -14,4 +14,6 @@
     method to return a :obj:`np.ndarray` instead of a dictionary, you can use the
     :class:`gym.wrappers.FlattenObservation` wrapper to flatten the dictionary into a
     single :obj:`np.ndarray`.
+
+.. _`Pybullet`: https://pybullet.org/
 """

--- a/stable_gym/envs/robotics/minitaur_cost/README.md
+++ b/stable_gym/envs/robotics/minitaur_cost/README.md
@@ -1,0 +1,67 @@
+# MinitaurCost gymnasium environment
+
+<div align="center">
+    <img src="https://github.com/rickstaa/stable-gym/assets/17570430/541b3e99-a4f3-44af-a3e4-8b9b478a54b9" alt="Minitaur Cost environment" width="200px">
+</div>
+</br>
+
+An actuated 8-jointed Minitaur. This environment corresponds to the [MinitaurBulletEnv-v0](https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/gym/pybullet_envs/bullet/minitaur_gym_env.py) environment included in the [pybullet package](https://pybullet.org/). It is different in the fact that:
+
+*   The objective was changed to a velocity-tracking task. To do this, the
+    reward is replaced with a cost. This cost is the squared difference between
+    the Minitaur's forward velocity and a reference value (error). Additionally,
+    also a energy cost and health penalty can be included in the cost.
+*   A minimal backward velocity bound is added to prevent the Minitaur from
+    walking backwards.
+*   Users are given the option to modify the Minitaur fall criteria, and thus
+    the episode termination criteria.
+
+The rest of the environment is the same as the original Minitaur environment. Please refer to the [original codebase](https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/gym/pybullet_envs/bullet/minitaur_gym_env.py) or [the article of Tan et al. 2018](https://arxiv.org/abs/1804.10332) on which the Minitaur environment is based for more information.
+
+## Observation space
+
+The observation space contains all eight motors' angles, velocities and torques.
+
+## Action space
+
+The action space contains the desired motor angles for all eight motors.
+
+## Episode Termination
+
+An episode is terminated when:
+
+*   The episode is terminated if the Minitaur falls, meaning that the
+    the orientation between the base and the world is greater than a threshold or
+    the base is too close to the ground.
+*   **Optionally**, the episode can be terminated if the Minitaur walks backwards.
+
+## Environment goal
+
+The Minitaur should walk forward with a certain velocity.
+
+## Cost function
+
+The cost function of this environment is designed in such a way that it tries to minimize the error between the Minitaur's forward velocity and a reference value. The cost function is defined as:
+
+$$
+cost = w_{forward\_velocity} \\times (x_{velocity} - x_{reference\_x\_velocity})^2 + w_{energy} \\times c_{energy} + w_{shake} \\times c_{shake} + w_{drift} \\times c_{drift} + p_{health}
+$$
+
+Where:
+
+*   $w_{forward\_velocity}$ - is the weight of the forward velocity error.
+*   $x_{velocity}$ - is the HopMintaur's forward velocity.
+*   $x_{reference\_x\_velocity}$ is the reference forward velocity.
+*   $w_{energy}$ is the weight of the energy cost (**optional**).
+*   $c_{energy}$ is the control energy cost (**optional**).
+*   $w_{shake}$ is the weight of the shake cost (**optional**).
+*   $c_{shake}$ is the shake (z movement) cost (**optional**).
+*   $w_{drift}$ is the weight of the drift (y movement) cost (**optional**).
+*   $c_{drift}$ is the drift cost (**optional**).
+*   $p_{health}$ is a penalty for being unhealthy (i.e. if the Minitaur falls over).
+
+The energy, shake, drift, and health penalty are optional and can be disabled using the `include_energy_cost`, `include_shake_cost`, `include_drift_cost` and `include_health_penalty` environment arguments.
+
+## How to use
+
+This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:MinitaurCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/robotics/minitaur_cost/__init__.py
+++ b/stable_gym/envs/robotics/minitaur_cost/__init__.py
@@ -1,0 +1,17 @@
+"""Modified version of the `Minitaur environment`_ in v3.2.5 of the `pybullet package`_.
+This modification was first described by `Han et al. 2020`_. In this modified version:
+
+-   The objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost.
+    This cost is the squared difference between the Minitaur's forward velocity and a reference value (error).
+-   A minimal backward velocity bound is added to prevent the Minitaur from
+    walking backwards.
+-   Users are given the option to modify the Minitaur fall criteria and thus
+    the episode termination criteria.
+
+.. _`Minitaur environment`: https://arxiv.org/abs/1804.10332
+.. _`pybullet package`:  https://pybullet.org/
+.. _`Han et al. 2020`: https://arxiv.org/abs/2004.14288
+"""  # noqa: E501
+from stable_gym.envs.robotics.minitaur_cost.minitaur_cost import (
+    MinitaurCost,
+)

--- a/stable_gym/envs/robotics/minitaur_cost/minitaur_cost.py
+++ b/stable_gym/envs/robotics/minitaur_cost/minitaur_cost.py
@@ -1,0 +1,517 @@
+"""The MinitaurCost gymnasium environment."""
+import gymnasium as gym
+import matplotlib.pyplot as plt
+import numpy as np
+from gymnasium import utils
+from pybullet_envs.bullet.minitaur_gym_env import MinitaurBulletEnv
+
+from stable_gym import ENVS  # noqa: F401
+from stable_gym.common.utils import change_dict_key, convert_gym_box_to_gymnasium_box
+
+EPISODES = 10  # Number of env episodes to run when __main__ is called.
+RANDOM_STEP = True  # Use random action in __main__. Zero action otherwise.
+
+# Retrieve max episode steps from the ENVS dict.
+# NOTE: Needed for default health penalty size.
+MAX_EPISODE_STEPS = ENVS["MinitaurCost-v1"]["max_episode_steps"]
+
+
+# TODO: Update solving criteria after training.
+class MinitaurCost(MinitaurBulletEnv, utils.EzPickle):
+    """Custom Minitaur gymnasium environment.
+
+    .. note::
+        Can also be used in a vectorized manner. See the
+        :gymnasium:`gym.vector <api/vector>` documentation.
+
+    Source:
+        Modified version of the `Minitaur environment`_ in v3.2.5 of the
+        `pybullet package`_. This modification was first described by
+        `Han et al. 2020`_. In this modified version:
+
+        -   The objective was changed to a velocity-tracking task. To do this, the
+            reward is replaced with a cost. This cost is the squared difference between
+            the Minitaur's forward velocity and a reference value (error). Additionally,
+            also a energy cost and health penalty can be included in the cost.
+        -   A minimal backward velocity bound is added to prevent the Minitaur from
+            walking backwards.
+        -   Users are given the option to modify the Minitaur fall criteria, and thus
+            the episode termination criteria.
+
+        The rest of the environment is the same as the original Minitaur environment.
+        Please refer to the `original codebase`_ or `the article of Tan et al. 2018`_ on
+        which the Minitaur environment is based for more information.
+
+    .. _`Minitaur environment`: https://arxiv.org/abs/1804.10332
+    .. _`pybullet package`:  https://pybullet.org/
+    .. _`Han et al. 2020`: https://arxiv.org/abs/2004.14288
+    .. _`original codebase`: https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/gym/pybullet_envs/bullet/minitaur_gym_env.py
+    .. _`the article of Tan et al. 2018`: https://arxiv.org/abs/1804.10332
+
+    Observation:
+        **Type**: Box(28)
+
+        The angles, velocities and torques of all motors.
+
+    Actions:
+        **Type**: Box(8)
+
+        A list of desired motor angles for eight motors.
+
+    Modified cost:
+        .. math::
+
+            cost = w_{forward\_velocity} \\times (x_{velocity} - x_{reference\_x\_velocity})^2 + w_{ctrl} \\times c_{ctrl} + p_{health}
+
+    Starting State:
+        The robot always starts at the same position and orientation, with zero
+        velocity.
+
+    Episode Termination:
+        -   The episode is terminated if the Minitaur falls, meaning that the
+            the orientation between the base and the world is greater than a threshold or
+            the base is too close to the ground.
+        -   Optionally, the episode can be terminated if the Minitaur walks backwards.
+
+    Solved Requirements:
+        Considered solved when the average cost is less than or equal to 50 over
+        100 consecutive trials.
+
+    How to use:
+        .. code-block:: python
+
+            import stable_gym
+            import gymnasium as gym
+            env = gym.make("MinitaurCost-v1")
+
+    Attributes:
+        state (numpy.ndarray): The current system state.
+        reference_forward_velocity (float): The forward velocity that the agent should
+            try to track.
+
+    .. attention::
+        Since the :meth:`~pybullet_envs.bullet.minitaur_gym_env.MinitaurBulletEnv`
+        is not yet compatible with :gymnasium:`gymnasium v>=0.26.0 <>`, the
+        :class:`gym.wrappers.EnvCompatibility` wrapper is used. This has the
+        side effect that the ``render_mode`` argument is not working. Instead,
+        the ``render`` argument should be used.
+    """  # noqa: E501, W605
+
+    # Replace deprecated metadata keys with new ones.
+    # See https://github.com/openai/gym/pull/2654.
+    # TODO: Can be removed when https://github.com/bulletphysics/bullet3/issues/4369 is resoled. # noqa: E501
+    metadata = MinitaurBulletEnv.metadata
+    change_dict_key(metadata, "render.modes", "render_modes")
+
+    def __init__(
+        self,
+        reference_forward_velocity=1.0,
+        randomise_reference_forward_velocity=False,
+        randomise_reference_forward_velocity_range=(0.5, 1.5),
+        forward_velocity_weight=1.0,
+        include_energy_cost=False,
+        energy_weight=0.005,
+        include_shake_cost=False,
+        shake_weight=0.01,  # NOTE: 0.0 in original environment.
+        include_drift_cost=False,  # NOTE: 0.05 in original environment.
+        drift_weight=0.01,
+        distance_limit=float("inf"),
+        render=False,
+        include_health_penalty=True,
+        health_penalty_size=None,
+        backward_velocity_bound=-0.5,
+        fall_criteria_up_rotation=0.85,
+        fall_criteria_z_position=0.13,
+        exclude_reference_from_observation=False,
+        exclude_reference_error_from_observation=True,  # NOTE: False in Han et al. 2018. # noqa: E501
+        exclude_x_velocity_from_observation=False,
+        **kwargs,
+    ):
+        """Initialise a new MinitaurCost environment instance.
+
+        Args:
+            reference_forward_velocity (float, optional): The forward velocity that the
+                agent should try to track. Defaults to ``1.0``.
+            randomise_reference_forward_velocity (bool, optional): Whether to randomize
+                the reference forward velocity. Defaults to ``False``.
+            randomise_reference_forward_velocity_range (tuple, optional): The range of
+                the random reference forward velocity. Defaults to ``(0.5, 1.5)``.
+            forward_velocity_weight (float, optional): The weight used to scale the
+                forward velocity error. Defaults to ``1.0``.
+            include_energy_cost (bool, optional): Whether to include the energy cost in
+                the cost function (i.e. energy of the motors). Defaults to ``False``.
+            energy_weight (float, optional): The weight used to scale the energy cost.
+                Defaults to ``0.005``.
+            include_shake_cost (bool, optional): Whether to include the shake cost in
+                the cost function (i.e. moving up and down). Defaults to ``False``.
+            shake_weight (float, optional): The weight used to scale the shake cost.
+                Defaults to ``0.01``.
+            include_drift_cost (bool, optional): Whether to include the drift cost in
+                the cost function (i.e. movement in the y direction). Defaults to
+                ``False``.
+            drift_weight (float, optional): The weight used to scale the drift cost.
+                Defaults to ``0.01``.
+            distance_limit (float, optional): The max distance (in meters) that the
+                agent can travel before the episode is terminated. Defaults to
+                ``float("inf")``.
+            render (bool, optional): Whether to render the environment. Defaults to
+                ``False``.
+            include_health_penalty (bool, optional): Whether to penalize the Minitaur if
+                it becomes unhealthy (i.e. if it falls over). Defaults to ``True``.
+            health_penalty_size (int, optional): The size of the unhealthy penalty.
+                Defaults to ``None``. Meaning the penalty is equal to the max episode
+                steps and the steps taken.
+            backward_velocity_bound (float): The max backward velocity (in meters per
+                second) before the episode is terminated. Defaults to ``-0.5``.
+            fall_criteria_up_rotation (float): The max up rotation (in radians) between
+                the base and the world before the episode is terminated. Defaults to
+                ``0.85``.
+            fall_criteria_z_position (float): The max z position (in meters) before the
+                episode is terminated. Defaults to ``0.13``.
+            exclude_reference_from_observation (bool, optional): Whether the reference
+                should be excluded from the observation. Defaults to ``False``. Can only
+                be set to ``True`` if ``randomise_reference_forward_velocity`` is set to
+                ``False``.
+            exclude_reference_error_from_observation (bool, optional): Whether the error
+                should be excluded from the observation. Defaults to ``True``.
+            exclude_x_velocity_from_observation (bool, optional): Whether to omit the
+                x- component of the velocity from observations. Defaults to ``False``.
+            **kwargs: Extra keyword arguments to pass to the :class:`MinitaurBulletEnv`
+                class.
+        """  # noqa: E501
+        self.state = None
+        self.t = 0.0
+        self.reference_forward_velocity = reference_forward_velocity
+        self._randomise_reference_forward_velocity = (
+            randomise_reference_forward_velocity
+        )
+        self._randomise_reference_forward_velocity_range = (
+            randomise_reference_forward_velocity_range
+        )
+        self._forward_velocity_weight = forward_velocity_weight
+        self._include_energy_cost = include_energy_cost
+        self._energy_weight = energy_weight
+        self._include_shake_cost = include_shake_cost
+        self._shake_weight = shake_weight
+        self._include_drift_cost = include_drift_cost
+        self._drift_weight = drift_weight
+        self._include_health_penalty = include_health_penalty
+        self._health_penalty_size = health_penalty_size
+        self._backward_velocity_bound = backward_velocity_bound
+        self._fall_criteria_up_rotation = fall_criteria_up_rotation
+        self._fall_criteria_z_position = fall_criteria_z_position
+        self._exclude_reference_from_observation = exclude_reference_from_observation
+        self._exclude_reference_error_from_observation = (
+            exclude_reference_error_from_observation
+        )
+        self._exclude_x_velocity_from_observation = exclude_x_velocity_from_observation
+
+        # Validate input arguments.
+        assert (
+            not randomise_reference_forward_velocity
+            or not exclude_reference_from_observation
+        ), (
+            "The reference can only be excluded from the observation if the forward "
+            "velocity is not randomised."
+        )
+
+        # Initialise the MinitaurBulletEnv class.
+        super().__init__(
+            energy_weight=energy_weight,
+            shake_weight=shake_weight,
+            drift_weight=drift_weight,
+            distance_limit=distance_limit,
+            render=render,
+            **kwargs,
+        )
+
+        # Convert gym spaces to gymnasium spaces.
+        # TODO: Can be removed when https://github.com/bulletphysics/bullet3/issues/4369 is resoled. # noqa: E501
+        self.observation_space = convert_gym_box_to_gymnasium_box(
+            self.observation_space
+        )
+        self.action_space = convert_gym_box_to_gymnasium_box(self.action_space)
+
+        # Extend observation space if necessary.
+        low = self.observation_space.low
+        high = self.observation_space.high
+        if not self._exclude_reference_from_observation:
+            low = np.append(low, -np.inf)
+            high = np.append(high, np.inf)
+        if not self._exclude_reference_error_from_observation:
+            low = np.append(low, -np.inf)
+            high = np.append(high, np.inf)
+        if not self._exclude_x_velocity_from_observation:
+            low = np.append(low, -np.inf)
+            high = np.append(high, np.inf)
+        self.observation_space = gym.spaces.Box(
+            low,
+            high,
+            dtype=self.observation_space.dtype,
+            seed=self.observation_space.np_random,
+        )
+
+        # Reinitialize the EzPickle class.
+        # NOTE: Done to ensure the args of the MinitaurCost class are also pickled.
+        # NOTE: Ensure that all args are passed to the EzPickle class!
+        utils.EzPickle.__init__(
+            self,
+            reference_forward_velocity,
+            forward_velocity_weight,
+            include_energy_cost,
+            energy_weight,
+            include_shake_cost,
+            shake_weight,
+            include_drift_cost,
+            drift_weight,
+            distance_limit,
+            render,
+            include_health_penalty,
+            health_penalty_size,
+            backward_velocity_bound,
+            fall_criteria_up_rotation,
+            fall_criteria_z_position,
+            exclude_reference_from_observation,
+            exclude_reference_error_from_observation,
+            exclude_x_velocity_from_observation,
+            **kwargs,
+        )
+
+    def cost(self, x_velocity, energy_cost, drift_cost, shake_cost):
+        """Compute the cost of a given base x velocity, energy cost, shake cost and
+        drift cost.
+
+        Args:
+            x_velocity (float): The Minitaurs's base x velocity.
+            energy_cost (float): The energy cost (i.e. motor cost).
+            drift_cost (float): The drift (y movement) cost.
+            shake_cost (float): The shake (z movement) cost.
+
+        Returns:
+            (tuple): tuple containing:
+
+                -   cost (float): The cost of the action.
+                -   info (:obj:`dict`): Additional information about the cost.
+        """
+        velocity_cost = self._forward_velocity_weight * np.square(
+            x_velocity - self.reference_forward_velocity
+        )
+        cost = velocity_cost
+        if self._include_energy_cost:
+            cost += self._energy_weight * energy_cost
+        if self._include_shake_cost:
+            cost += self._shake_weight * shake_cost
+        if self._include_drift_cost:
+            cost += self._drift_weight * drift_cost
+
+        return cost, {
+            "cost_velocity": velocity_cost,
+            "energy_cost": energy_cost,
+            "cost_shake": shake_cost,
+            "cost_drift": drift_cost,
+        }
+
+    def step(self, action):
+        """Take step into the environment.
+
+        .. note::
+            This method overrides the
+            :meth:`~pybullet_envs.bullet.minitaur_gym_env.MinitaurBulletEnv.step` method
+            such that the new cost function is used.
+
+        Args:
+            action (np.ndarray): Action to take in the environment.
+            render_mode (str, optional): The render mode to use. Defaults to ``None``.
+
+        Returns:
+            (tuple): tuple containing:
+
+                -   obs (:obj:`np.ndarray`): Environment observation.
+                -   cost (:obj:`float`): Cost of the action.
+                -   terminated (:obj:`bool`): Whether the episode is terminated.
+                -   truncated (:obj:`bool`): Whether the episode was truncated. This
+                    value is set by wrappers when for example a time limit is reached or
+                    the agent goes out of bounds.
+                -   info (:obj:`dict`): Additional information about the environment.
+        """
+        obs, _, terminated, info = super().step(action)
+
+        # Add reference, x velocity and reference error to observation.
+        base_velocity = self.base_velocity
+        if not self._exclude_reference_from_observation:
+            obs = np.append(obs, self.reference_forward_velocity)
+        if not self._exclude_reference_error_from_observation:
+            obs = np.append(obs, base_velocity - self.reference_forward_velocity)
+        if not self._exclude_x_velocity_from_observation:
+            obs = np.append(obs, base_velocity)
+
+        self.state = obs
+        self.t = self.t + self.dt
+
+        # Retrieve original rew5ards and base velocity.
+        # NOTE: Han et al. 2018 used the squared error for the drift reward. We use the
+        # version found in the original Minitaur environment (i.e. absolute distance).
+        objectives = self.get_objectives()
+        last_rewards = objectives[-1]
+        _, energy_reward, drift_reward, shake_reward = last_rewards
+        drift_cost, shake_cost = -drift_reward, -shake_reward
+
+        # Compute the cost and update the info dict.
+        cost, cost_info = self.cost(
+            self.base_velocity, energy_reward, drift_cost, shake_cost
+        )
+        info.update(cost_info)
+
+        # Add optional health penalty at the end of the episode if requested.
+        if self._include_health_penalty:
+            if terminated:
+                if self._health_penalty_size is not None:
+                    cost += self._health_penalty_size
+                else:  # If not set add unperformed steps to the cost.
+                    cost += MAX_EPISODE_STEPS - self._env_step_counter
+
+        return obs, cost, terminated, info
+
+    def reset(self):
+        """Reset gymnasium environment.
+
+        Returns:
+            (np.ndarray): Initial environment observation.
+        """
+        obs = super().reset()
+
+        # Randomize the reference forward velocity if requested.
+        if self._randomise_reference_forward_velocity:
+            self.reference_forward_velocity = self.np_random.uniform(
+                *self._randomise_reference_forward_velocity_range
+            )
+
+        # Add reference, x velocity and reference error to observation.
+        if not self._exclude_reference_from_observation:
+            obs = np.append(obs, self.reference_forward_velocity)
+        if not self._exclude_reference_error_from_observation:
+            obs = np.append(obs, 0.0 - self.reference_forward_velocity)
+        if not self._exclude_x_velocity_from_observation:
+            obs = np.append(obs, 0.0)
+
+        self.state = obs
+        self.t = 0.0
+
+        return obs
+
+    def _termination(self):
+        """Check whether the episode is terminated.
+
+        .. note::
+            This method overrides the :meth:`_termination` method of the original
+            Minitaur environment so that we can also set a minimum velocity criteria.
+
+        Returns:
+            (bool): Boolean value that indicates whether the episode is terminated.
+        """
+        # NOTE: Han et al. 2018 returns `FALSE` here. We use the original termination
+        # criteria from the Minitaur environment + a minimum velocity criteria.
+        terminated = super()._termination()
+
+        # Check if the minotaur is moved backwards.
+        if self._backward_velocity_bound is not None:
+            base_velocity = self.base_velocity
+            if base_velocity <= self._backward_velocity_bound:
+                terminated = True
+
+        return terminated
+
+    def is_fallen(self):
+        """Check whether the minitaur has fallen.
+
+        If the up directions (i.e. angle) between the base and the world are larger
+        (the dot product is smaller than :attr:`._fall_criteria_up_rotation`) or the
+        base is close to the ground (the height is smaller than
+        :attr:`._fall_criteria_z_position`), the minitaur is considered fallen.
+
+        .. note::
+            This method overrides the :meth:`is_fallen` method of the original
+            Minitaur environment to give users the ability to set the fall criteria.
+
+        Returns:
+            (bool): Boolean value that indicates whether the minitaur has fallen.
+        """
+        # NOTE: Han et al. 2018 doesn't use the z position criteria.
+        orientation = self.minitaur.GetBaseOrientation()
+        rot_mat = self._pybullet_client.getMatrixFromQuaternion(orientation)
+        local_up = rot_mat[6:]
+        pos = self.minitaur.GetBasePosition()
+        return (
+            np.dot(np.asarray([0, 0, 1]), np.asarray(local_up))
+            < self._fall_criteria_up_rotation
+            or pos[2] < self._fall_criteria_z_position
+        )
+
+    @property
+    def base_velocity(self):
+        """The base velocity of the minitaur."""
+        objectives = self.get_objectives()
+        forward_reward = objectives[-1][
+            0
+        ]  # NOTE: Forward_reward is x distance travelled in 1 time-step.
+        base_velocity = forward_reward / self.dt
+        return base_velocity
+
+    @property
+    def dt(self):
+        """The environment step size."""
+        return self._time_step
+
+    @property
+    def tau(self):
+        """Alias for the environment step size. Done for compatibility with the
+        other gymnasium environments.
+        """
+        return self._time_step
+
+
+if __name__ == "__main__":
+    print("Setting up 'MinitaurCost' environment.")
+    env = gym.make("MinitaurCost", render=True)
+
+    # Run episodes.
+    episode = 0
+    path, paths = [], []
+    s, _ = env.reset()
+    path.append(s)
+    print(f"\nPerforming '{EPISODES}' in the 'MinitaurCost' environment...\n")
+    print(f"Episode: {episode}")
+    while episode <= EPISODES:
+        action = (
+            env.action_space.sample()
+            if RANDOM_STEP
+            else np.zeros(env.action_space.shape)
+        )
+        s, r, terminated, truncated, _ = env.step(action)
+        path.append(s)
+        if terminated or truncated:
+            paths.append(path)
+            episode += 1
+            path, reference = [], []
+            s, _ = env.reset()
+            path.append(s)
+            print(f"Episode: {episode}")
+    print("\nFinished 'MinitaurCost' environment simulation.")
+
+    # Plot results per episode.
+    print("\nPlotting episode data...")
+    for i in range(len(paths)):
+        path = paths[i]
+        fig, ax = plt.subplots()
+        print(f"\nEpisode: {i}")
+        path = np.array(path)
+        t = np.linspace(0, path.shape[0] * env.unwrapped.env.dt, path.shape[0])
+        for j in range(path.shape[1]):  # NOTE: Change if you want to plot less states.
+            ax.plot(t, path[:, j], label=f"State {j}")
+        ax.set_xlabel("Time (s)")
+        ax.set_title(f"MinitaurCost episode '{i}'")
+        ax.legend()
+        print("Close plot to see next episode...")
+        plt.show()
+
+    print("\nDone")

--- a/stable_gym/envs/robotics/minitaur_cost/requirements.txt
+++ b/stable_gym/envs/robotics/minitaur_cost/requirements.txt
@@ -1,0 +1,3 @@
+gymnasium-robotics==1.2.2
+matplotlib==3.7.0
+pybullet==3.2.5

--- a/tests/__snapshots__/test_minitaur_cost.ambr
+++ b/tests/__snapshots__/test_minitaur_cost.ambr
@@ -1,0 +1,648 @@
+# serializer version: 1
+# name: TestMinitaurCostEqual.test_snapshot
+  1.4921882851926276
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.1
+  1.4789271033865865
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.10
+  1.0663496355371027
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.100
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.101
+  dict({
+    'cost_drift': 0.00026510064533499973,
+    'cost_shake': 0.001545201927514478,
+    'cost_velocity': 1.2628780090552525,
+    'energy_cost': 0.20818703830012608,
+  })
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.102
+  1.4545558312421683
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.103
+  1.6117357153245735
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.104
+  1.4075151555523995
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.105
+  1.6396477365894244
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.106
+  1.3025010248257614
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.107
+  1.721843549526664
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.108
+  1.3656871490104912
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.109
+  1.5795080865342341
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.11
+  1.0943587809259567
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.110
+  4.0987608316202575
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.111
+  -4.762556888733957
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.112
+  2.2002813098693443
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.113
+  25.53808932629984
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.114
+  -19.11056347163142
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.115
+  -0.23017069533937498
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.116
+  -8.760987035583328
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.117
+  -0.6161326682556563
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.118
+  1.199272224657645
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.119
+  -0.6339403199697413
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.12
+  0.995603541185548
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.120
+  -0.11231117189806678
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.121
+  5.7
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.122
+  -2.4722324662009885
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.123
+  0.2233009558749279
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.124
+  -0.5835839044021457
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.125
+  -0.08195822137720803
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.126
+  0.0015080091209053578
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.127
+  -0.005047252262417167
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.128
+  -0.0011210711906729715
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.129
+  0.9999854970710707
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.13
+  0.9624862628386269
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.130
+  1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.131
+  -1.1436856755614642
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.132
+  -0.1436856755614642
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.133
+  1.3080169244844826
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.134
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.135
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.136
+  dict({
+    'cost_drift': 0.0003031150414334095,
+    'cost_shake': 0.0012169545336557508,
+    'cost_velocity': 1.3080169244844826,
+    'energy_cost': 0.41122465226046057,
+  })
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.137
+  1.5341615570870843
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.138
+  1.667503345811441
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.139
+  1.336984693762328
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.14
+  1.001677592676643
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.140
+  1.6998782255887888
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.141
+  1.2846803432803098
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.142
+  1.6870219142241003
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.143
+  1.4158688126858348
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.144
+  1.409299290532422
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.145
+  2.27414898187841
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.146
+  4.963395768653195
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.147
+  -8.01643431072371
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.148
+  3.9373116427800157
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.149
+  7.569080022380718
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.15
+  0.9839904897221291
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.150
+  -4.57929638695922
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.151
+  12.740169561588154
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.152
+  -26.5732373271626
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.153
+  5.7
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.154
+  2.336953272639927
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.155
+  -0.032444422912505363
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.156
+  3.335296380285704
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.157
+  2.3368391745171873
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.158
+  -0.6987519149533734
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.159
+  2.9824401251824773
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.16
+  0.47928237547358815
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.160
+  -4.0975567633530865
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.161
+  0.0036768238712320666
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.162
+  -0.009422872678285548
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.163
+  -0.0014361066766253082
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.164
+  0.9999478126554016
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.165
+  1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.166
+  -1.0292195060479763
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.167
+  -0.029219506047976396
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.168
+  1.0592927916296404
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.169
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.17
+  0.5837120895589282
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.170
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.171
+  dict({
+    'cost_drift': 0.0007753196086186459,
+    'cost_shake': 0.0010624252806621381,
+    'cost_velocity': 1.0592927916296404,
+    'energy_cost': 0.4114474382080177,
+  })
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.172
+  1.569906766790782
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.173
+  1.7331056888843241
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.174
+  1.3237133707193192
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.175
+  1.742273610524191
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.176
+  1.5302292288489472
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.177
+  1.8004621273218768
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.178
+  1.640664527740089
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.179
+  1.2725314936086671
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.18
+  0.5257100908059869
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.180
+  4.539298372549965
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.181
+  7.723891293735937
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.182
+  -0.5936666290000421
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.183
+  3.4213390772054755
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.184
+  33.03323435301229
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.185
+  18.795834310416726
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.186
+  24.444872563344553
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.187
+  -7.45018926685021
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.188
+  5.14492136132931
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.189
+  5.7
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.19
+  0.6169541044703496
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.190
+  3.8843775027841305
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.191
+  3.2205320592727427
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.192
+  3.0514155101415974
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.193
+  2.080158007903896
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.194
+  0.8181289409641633
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.195
+  0.9724706139415574
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.196
+  0.006187289928265384
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.197
+  -0.017578239634415644
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.198
+  -0.0019646222878507914
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.199
+  0.9998244161821438
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.2
+  1.486254010404662
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.20
+  0.45444738007400126
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.200
+  1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.201
+  -1.0058906736836641
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.202
+  -0.005890673683664233
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.203
+  1.0118160474037756
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.204
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.205
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.206
+  dict({
+    'cost_drift': 0.0011858287372491253,
+    'cost_shake': 0.002593163820677369,
+    'cost_velocity': 1.0118160474037756,
+    'energy_cost': 0.4574868338110529,
+  })
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.21
+  0.42391213180303916
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.22
+  0.46479927253152703
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.23
+  0.45789504049009405
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.24
+  -0.0021500387145343826
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.25
+  0.000863217812250218
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.26
+  -0.0002786489936196694
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.27
+  0.9999972772679299
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.28
+  1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.29
+  -1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.3
+  1.4746404563135436
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.30
+  0.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.31
+  dict({
+  })
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.32
+  1.5273013017892785
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.33
+  1.5231278286826746
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.34
+  1.4049667493941906
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.35
+  1.4385761210072923
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.36
+  1.405281888521337
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.37
+  1.619926447555798
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.38
+  1.4344652906641657
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.39
+  1.5555809841265893
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.4
+  1.4959923210163817
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.40
+  1.415422211917737
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.41
+  2.9322409537036815
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.42
+  -10.990567306788762
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.43
+  -4.6288121204119905
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.44
+  -13.017550797541734
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.45
+  17.203564565236658
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.46
+  -8.366632194274024
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.47
+  8.063093644419762
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.48
+  5.7
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.49
+  4.775196021005619
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.5
+  1.5003442097217625
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.50
+  -0.8098822946051397
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.51
+  -0.36943569983676483
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.52
+  -1.6763895876361308
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.53
+  1.806652257694434
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.54
+  -0.7551495655853833
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.55
+  1.107457152881377
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.56
+  -0.0014522922606466481
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.57
+  -0.0010881361702168905
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.58
+  -0.0009161198058361459
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.59
+  0.9999979337635484
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.6
+  1.4946713778208265
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.60
+  1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.61
+  -1.0713327014650966
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.62
+  -0.07133270146509657
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.63
+  1.147753757228502
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.64
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.65
+  False
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.66
+  dict({
+    'cost_drift': 0.0008900027558481863,
+    'cost_shake': 0.15895416214882663,
+    'cost_velocity': 1.147753757228502,
+    'energy_cost': 0.20166396206144432,
+  })
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.67
+  1.4586963043678636
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.68
+  1.6098315038307582
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.69
+  1.3677618967187597
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.7
+  1.495840237585695
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.70
+  1.4527762697881978
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.71
+  1.416120832041941
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.72
+  1.7247459651082455
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.73
+  1.4379015596146527
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.74
+  1.5913847069004636
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.75
+  -9.94383775017649
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.76
+  16.340418493372578
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.77
+  -1.0389012894191214
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.78
+  3.262464708638372
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.79
+  5.498044263657464
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.8
+  1.0501221522620467
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.80
+  3.5689999125794483
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.81
+  0.2217681739713786
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.82
+  -0.9718621932166256
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.83
+  -1.2172762371661339
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.84
+  4.061732960977945
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.85
+  0.386457403859728
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.86
+  0.2689634259529951
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.87
+  5.7
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.88
+  -0.31999803038762237
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.89
+  2.189439098465523
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.9
+  1.0801084244609196
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.90
+  5.7
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.91
+  -0.0004593510945333464
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.92
+  -0.004677848976264771
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.93
+  -0.0013348435128684088
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.94
+  0.9999880623879084
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.95
+  1.0
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.96
+  -1.1237784519447116
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.97
+  -0.12377845194471158
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.98
+  1.2628780090552525
+# ---
+# name: TestMinitaurCostEqual.test_snapshot.99
+  False
+# ---

--- a/tests/test_minitaur_cost.py
+++ b/tests/test_minitaur_cost.py
@@ -1,21 +1,44 @@
-"""Test if the Walker2dCost environment still behaves like the original Walker2d
+"""Test if the MinitaurCost environment still behaves like the original Minitaur
 environment when the same environment parameters are used.
 """
 import gymnasium as gym
 import numpy as np
 from gymnasium.logger import ERROR
-
-import stable_gym  # noqa: F401
+from gym.logger import ERROR as ERROR_ORG
 
 gym.logger.set_level(ERROR)
 
+import stable_gym  # noqa: F401, E402
 
-class TestWalker2dCostEqual:
-    # Make original Walker2d environment.
-    env = gym.make("Walker2d")
-    # Make Walker2dCost environment.
+import gym as gym_orig  # noqa: E402
+
+gym_orig.logger.set_level(
+    ERROR_ORG
+)  # TODO: Can be removed when https://github.com/bulletphysics/bullet3/issues/4369 is resoled. # noqa: E501
+import pybullet_envs  # noqa: F401, E402
+
+
+# Register Minitaur environment. Needed because the original Minitaur environment
+# is registered under 'gym' instead of 'gymnasium'.
+# TODO: Can be removed when https://github.com/bulletphysics/bullet3/issues/4369 is resoled. # noqa: E501
+gym.register(
+    id="MinitaurBulletEnv-v0",
+    entry_point="pybullet_envs.bullet.minitaur_gym_env:MinitaurBulletEnv",
+    max_episode_steps=500,
+    reward_threshold=300,
+    disable_env_checker=True,
+    apply_api_compatibility=True,
+)
+
+
+class TestMinitaurCostEqual:
+    # NOTE: The env randomizer is disabled because it is not deterministic.
+    # Make original Minitaur environment.
+    env = gym.make("MinitaurBulletEnv-v0", env_randomizer=None)
+    # Make MinitaurCost environment.
     env_cost = gym.make(
-        "Walker2dCost",
+        "MinitaurCost",
+        env_randomizer=None,
         exclude_reference_from_observation=True,
         exclude_x_velocity_from_observation=True,
     )
@@ -43,9 +66,11 @@ class TestWalker2dCostEqual:
             ), f"{observation} != {observation_cost}"
 
     def test_snapshot(self, snapshot):
-        """Test if the 'Walker2dCost' environment is still equal to snapshot."""
+        """Test if the 'MinitaurCost' environment is still equal to snapshot."""
         self.env_cost = gym.make(
-            "Walker2dCost", exclude_reference_error_from_observation=False
+            "MinitaurCost",
+            env_randomizer=None,
+            exclude_reference_error_from_observation=False,
         )  # Check full observation.
         observation, info = self.env_cost.reset(seed=42)
         assert (observation == snapshot).all()


### PR DESCRIPTION
This pull request adds a modified version of the [Minitaur environment](https://github.com/bulletphysics/bullet3/tree/master/examples/pybullet/gym/pybullet_data/quadruped) found in the [bullet3 package](https://pybullet.org/wordpress/) package. In this modified version, the objective was changed to a velocity-tracking task. To do this, the reward is replaced with a cost. This cost is the squared difference between the Minitaur's forward velocity and a reference value (error).
