### PR TITLE
fix(minitaurcost): fix 'MinitaurCost' health penalty calculation

### DIFF
--- a/stable_gym/__init__.py
+++ b/stable_gym/__init__.py
@@ -2,6 +2,10 @@
 import gymnasium as gym
 from gymnasium.envs.registration import register
 
+from stable_gym.common.inject_max_episode_steps_wrapper import (
+    MaxEpisodeStepsInjectionWrapper,
+)
+
 # Make entry_point version available.
 from .version import __version__, __version_tuple__
 
@@ -70,6 +74,7 @@ ENVS = {
         "reward_threshold": 300,
         "max_episode_steps": 500,
         "compatible": False,
+        "additional_wrappers": (MaxEpisodeStepsInjectionWrapper.wrapper_spec(),),
     },
 }
 
@@ -81,4 +86,7 @@ for env, val in ENVS.items():
         max_episode_steps=val["max_episode_steps"],
         disable_env_checker=not val["compatible"] if "compatible" in val else False,
         apply_api_compatibility=not val["compatible"] if "compatible" in val else False,
+        additional_wrappers=val["additional_wrappers"]
+        if "additional_wrappers" in val
+        else (),
     )

--- a/stable_gym/common/__init__.py
+++ b/stable_gym/common/__init__.py
@@ -1,4 +1,7 @@
 """Contains several functions that can be used across all the Stable Gym gymnasium
 environments.
 """
-from stable_gym.common.disturber import Disturber  # noqa: F401
+from stable_gym.common.disturber import Disturber
+from stable_gym.common.inject_max_episode_steps_wrapper import (
+    MaxEpisodeStepsInjectionWrapper,
+)

--- a/stable_gym/common/inject_max_episode_steps_wrapper.py
+++ b/stable_gym/common/inject_max_episode_steps_wrapper.py
@@ -1,0 +1,64 @@
+"""This file contains a small gymnasium wrapper that injects the `max_episode_steps`
+argument of a potentially nested `TimeLimit` wrapper into the base environment under the
+`_time_limit_max_episode_steps` attribute.
+"""
+import gymnasium as gym
+
+
+def get_time_limit_wrapper_max_episode_steps(env):
+    """Returns the ``max_episode_steps`` attribute of a potentially nested
+    ``TimeLimit`` wrapper.
+
+    Args:
+        env (gym.Env): The gymnasium environment.
+
+    Returns:
+        int: The value of the ``max_episode_steps`` attribute of a potentially nested
+            ``TimeLimit`` wrapper. If the environment is not wrapped in a ``TimeLimit``
+            wrapper, then this function returns ``None``.
+    """
+    if hasattr(env, "env"):
+        if isinstance(env, gym.wrappers.TimeLimit):
+            return env._max_episode_steps
+        get_time_limit_wrapper_max_episode_steps(env.env)
+    return None
+
+
+def inject_attribute_into_base_env(env, attribute_name, attribute_value):
+    """Injects the ``max_episode_steps`` argument into the base environment under the
+    `_time_limit_max_episode_steps` attribute.
+
+    Args:
+        env (gym.Env): The gymnasium environment.
+        attribute_name (str): The attribute's name to inject into the base
+            environment.
+        attribute_value (object): The attribute's value to inject into the base
+            environment.
+    """
+    if hasattr(env, "env"):
+        return inject_attribute_into_base_env(env.env, attribute_name, attribute_value)
+    setattr(env, attribute_name, attribute_value)
+
+
+class MaxEpisodeStepsInjectionWrapper(gym.Wrapper):
+    """A gymnasium wrapper that injects the ``max_episode_steps`` attribute of the
+    ``TimeLimit`` wrapper into the base environment as the
+    ``_time_limit_max_episode_steps`` attribute. If the environment is not wrapped in
+    a ``TimeLimit`` wrapper, then the ``_time_limit_max_episode_steps`` attribute is
+    set to ``None``.
+    """
+
+    def __init__(self, env):
+        """Wrap a gymnasium environment.
+        Args:
+            env (gym.Env): The gymnasium environment.
+        """
+        super().__init__(env)
+
+        # Retrieve max_episode_steps from potentially nested TimeLimit wrappers.
+        max_episode_steps = get_time_limit_wrapper_max_episode_steps(self.env)
+
+        # Inject the max_episode_steps attribute into the base environment.
+        inject_attribute_into_base_env(
+            self.env, "_time_limit_max_episode_steps", max_episode_steps
+        )


### PR DESCRIPTION
This pull request fixes the health penalty calculation in the `MinitaurCost` environment. In the old version, the penalty was incorrectly calculated when the user changed the `max_epsisode_steps` value during environment creation.
