### PR TITLE
refactor(biological/classical): fix small inconsistencies

### DIFF
--- a/stable_gym/envs/biological/oscillator/README.md
+++ b/stable_gym/envs/biological/oscillator/README.md
@@ -15,7 +15,7 @@ By default, the environment returns the following observation:
 *   $r$ - The reference we want to follow.
 *   $r_{error}$ - The error between the state of interest (i.e. $p_1$) and the reference.
 
-The last two variables can be excluded from the observation space by setting the `exclude_reference_from_observation` and `exclude_reference_error_from_observation` environment arguments to `True`. Please note that the environment needs the reference or the reference error to be included in the observation space to function correctly. If both are excluded, the environment will raise an error.
+The last two variables can be excluded from the observation space by setting the `exclude_reference_from_observation` and `exclude_reference_error_from_observation` environment arguments to `True`. Please note that the environment needs the reference or the reference error to be included in the observation space when the reference signal is not constant to function correctly. If both are excluded, the environment will raise an error.
 
 ## Action space
 

--- a/stable_gym/envs/biological/oscillator/oscillator.py
+++ b/stable_gym/envs/biological/oscillator/oscillator.py
@@ -137,7 +137,7 @@ class Oscillator(gym.Env, OscillatorDisturber):
             reference_target_position: The reference target position, by default
                 ``8.0`` (i.e. the mean of the reference signal).
             reference_amplitude: The reference amplitude, by default ``7.0``.
-            reference_frequency: The reference frequency, by default ``200``.
+            reference_frequency: The reference frequency, by default ``0.005``.
             reference_phase_shift: The reference phase shift, by default ``0.0``.
             clip_action (str, optional): Whether the actions should be clipped if
                 they are greater than the set action limit. Defaults to ``True``.
@@ -154,13 +154,13 @@ class Oscillator(gym.Env, OscillatorDisturber):
             exclude_reference_error_from_observation
         )
 
-        # Validate input arguments.
-        assert not (
+        # Validate input arguments.s
+        assert (reference_amplitude == 0 or reference_frequency == 0) or not (
             exclude_reference_from_observation
             and exclude_reference_error_from_observation
         ), (
             "The agent needs to observe either the reference or the reference error "
-            "for it to be able to learn."
+            "for it to be able to learn when the reference is not constant."
         )
         assert (
             reference_frequency >= 0

--- a/stable_gym/envs/biological/oscillator_complicated/README.md
+++ b/stable_gym/envs/biological/oscillator_complicated/README.md
@@ -17,7 +17,7 @@ By default, the environment returns the following observation:
 *   $r$ - The reference we want to follow.
 *   $r_{error}$ - The error between the state of interest (i.e. $p_1$) and the reference.
 
-The last two variables can be excluded from the observation space by setting the `exclude_reference_from_observation` and `exclude_reference_error_from_observation` environment arguments to `True`. Please note that the environment needs the reference or the reference error to be included in the observation space to function correctly. If both are excluded, the environment will raise an error.
+The last two variables can be excluded from the observation space by setting the `exclude_reference_from_observation` and `exclude_reference_error_from_observation` environment arguments to `True`. Please note that the environment needs the reference or the reference error to be included in the observation space when the reference signal is not constant to function correctly. If both are excluded, the environment will raise an error.
 
 ## Action space
 

--- a/stable_gym/envs/biological/oscillator_complicated/oscillator_complicated.py
+++ b/stable_gym/envs/biological/oscillator_complicated/oscillator_complicated.py
@@ -153,7 +153,7 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
             reference_target_position: The reference target position, by default
                 ``8.0`` (i.e. the mean of the reference signal).
             reference_amplitude: The reference amplitude, by default ``7.0``.
-            reference_frequency: The reference frequency, by default ``200``.
+            reference_frequency: The reference frequency, by default ``0.005``.
             reference_phase_shift: The reference phase shift, by default ``0.0``.
             clip_action (str, optional): Whether the actions should be clipped if
                 they are greater than the set action limit. Defaults to ``True``.
@@ -171,12 +171,12 @@ class OscillatorComplicated(gym.Env, OscillatorComplicatedDisturber):
         )
 
         # Validate input arguments.
-        assert not (
+        assert (reference_amplitude == 0 or reference_frequency == 0) or not (
             exclude_reference_from_observation
             and exclude_reference_error_from_observation
         ), (
             "The agent needs to observe either the reference or the reference error "
-            "for it to be able to learn."
+            "for it to be able to learn when the reference is not constant."
         )
         assert (
             reference_frequency >= 0

--- a/stable_gym/envs/classic_control/cartpole_cost/cartpole_cost.py
+++ b/stable_gym/envs/classic_control/cartpole_cost/cartpole_cost.py
@@ -146,8 +146,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         # NOTE: Custom environment arguments.
         max_cost=100.0,
         clip_action=True,
-        exclude_reference_from_observation=False,
-        exclude_reference_error_from_observation=True,
     ):
         """Initialise a new CartPoleCost environment instance.
 
@@ -186,10 +184,6 @@ class CartPoleCost(gym.Env, CartPoleDisturber):
         # Create observation space bounds.
         # Angle limit set to 2 * theta_threshold_radians so failing observation
         # is still within bounds.
-        self._exclude_reference_from_observation = exclude_reference_from_observation
-        self._exclude_reference_error_from_observation = (
-            exclude_reference_error_from_observation
-        )
         high = np.array(
             [
                 self.x_threshold * 2,

--- a/stable_gym/envs/classic_control/cartpole_tracking_cost/README.md
+++ b/stable_gym/envs/classic_control/cartpole_tracking_cost/README.md
@@ -28,7 +28,7 @@ By default, the environment returns the following observation:
 *   $x_{ref}$ - The cart position reference.
 *   $x_{ref\_error}$ - The reference tracking error.
 
-The last two variables can be excluded from the observation space by setting the `exclude_reference_from_observation` and `exclude_reference_error_from_observation` environment arguments to `True`. Please note that the environment needs the reference or the reference error to be included in the observation space to function correctly. If both are excluded, the environment will raise an error.
+The last two variables can be excluded from the observation space by setting the `exclude_reference_from_observation` and `exclude_reference_error_from_observation` environment arguments to `True`. Please note that the environment needs the reference or the reference error to be included in the observation space when the reference signal is not constant to function correctly. If both are excluded, the environment will raise an error.
 
 ## Action space
 

--- a/stable_gym/envs/classic_control/cartpole_tracking_cost/cartpole_tracking_cost.py
+++ b/stable_gym/envs/classic_control/cartpole_tracking_cost/cartpole_tracking_cost.py
@@ -156,7 +156,7 @@ class CartPoleTrackingCost(gym.Env, CartPoleDisturber):
         # NOTE: Custom environment arguments.
         reference_target_position=0.0,
         reference_amplitude=7.0,
-        reference_frequency=200,
+        reference_frequency=0.005,
         max_cost=100.0,
         clip_action=True,
         exclude_reference_from_observation=False,
@@ -169,7 +169,7 @@ class CartPoleTrackingCost(gym.Env, CartPoleDisturber):
             reference_target_position: The reference target position, by default
                 ``0.0`` (i.e. the mean of the reference signal).
             reference_amplitude: The reference amplitude, by default ``7.0``.
-            reference_frequency: The reference frequency, by default ``200``.
+            reference_frequency: The reference frequency, by default ``0.005``.
             max_cost (float, optional): The maximum cost allowed before the episode is
                 terminated. Defaults to ``100.0``.
             clip_action (str, optional): Whether the actions should be clipped if
@@ -182,12 +182,12 @@ class CartPoleTrackingCost(gym.Env, CartPoleDisturber):
         super().__init__()  # NOTE: Initialise disturber superclass.
 
         # Validate input arguments.
-        assert not (
+        assert (reference_amplitude == 0 or reference_frequency == 0) or not (
             exclude_reference_from_observation
             and exclude_reference_error_from_observation
         ), (
             "The agent needs to observe either the reference or the reference error "
-            "for it to be able to learn."
+            "for it to be able to learn when the reference is not constant."
         )
         assert (
             reference_frequency > 0


### PR DESCRIPTION
This pull request ensures the right frequency is used in the environments, and a warning is only thrown
about excluding the reference and reference error when the reference signal is not constant.
