### PR TITLE
Remove requirement for Numpy on PyFlyt

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,22 +1,22 @@
 name: Docs
-on: 
+on:
   push:
     tags:
       - v*.*.*
     paths:
-      - 'docs/**'
+      - "docs/**"
   workflow_dispatch:
 permissions:
-    contents: write
+  contents: write
 jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: 3.8
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: pyproject.toml
       - name: Install dependencies
         run: |

--- a/.github/workflows/stable_gym.yml
+++ b/.github/workflows/stable_gym.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: pyproject.toml
       - name: Install the stable_gym package with its dependencies
         run: |
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false # Run all matrix jobs.
       matrix:
-        python-version: [3.8, 3.9, '3.10'] # Supported python versions.
+        python-version: [3.8, 3.9, "3.10"] # Supported python versions.
     steps:
       - name: Checkout stable-gym repository
         uses: actions/checkout@v3
@@ -62,12 +62,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: pyproject.toml
-      # NOTE: The following is needed because PyFlyt requires pybullet to be build with numpy. See https://jjshoots.github.io/PyFlyt/documentation.html#installation.
-      - name: Install numpy before pybullet to ensure pybullet is built with numpy.
-        run: |
-          pip install numpy
       - name: Install the stable_gym package with its dependencies
         run: |
           pip install .[dev]
@@ -78,5 +74,5 @@ jobs:
           set +o pipefail
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        env: 
+        env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.8
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: pyproject.toml
       - name: Install the stable_gym package with its dependencies
         run: |
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false # Run all matrix jobs.
       matrix:
-        python-version: [3.8, 3.9, '3.10'] # Supported python versions.
+        python-version: [3.8, 3.9, "3.10"] # Supported python versions.
     steps:
       - name: Checkout stable-gym repository
         uses: actions/checkout@v3
@@ -80,12 +80,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: pyproject.toml
-      # NOTE: The following is needed because PyFlyt requires pybullet to be build with numpy. See https://jjshoots.github.io/PyFlyt/documentation.html#installation.
-      - name: Install numpy before pybullet to ensure pybullet is built with numpy.
-        run: |
-          pip install numpy
       - name: Install the stable_gym package with its dependencies
         run: |
           pip install .[dev]
@@ -102,5 +98,5 @@ jobs:
           path: pytest/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
-        env: 
+        env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,6 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 > \[!NOTE]\
 > When working on different machines, the snapshots could be slightly different. This is because the random seeds are sometimes dependent on the machine architecture. To fix this, please temporarily [stash your changes](https://git-scm.com/book/en/v2/Git-Tools-Stashing-and-Cleaning) or return to the latest upstream commit and run the `npm run test:update:snapshots` command. You can then add your change again and run the tests.
 
-> \[!NOTE]\
-> On some systems, the Quadrotor tests fail because [PyBullet](https://pybullet.org/wordpress/) is installed without [numpy](https://numpy.org/) support. If you run into problems, please remove [PyBullet](https://pybullet.org/wordpress/) package, ensure [numpy](https://numpy.org/) is installed, and reinstall [PyBullet](https://pybullet.org/wordpress/) using the `--no-cache-dir` flag (see the [PyFlyt documentation](https://jjshoots.github.io/PyFlyt/documentation.html#installation) for more information).
-
 ### Report bugs using Github's [issues](https://github.com/rickstaa/stable-gym/issues)
 
 <!--alex ignore easy-->

--- a/docs/source/envs/envs.rst
+++ b/docs/source/envs/envs.rst
@@ -4,7 +4,7 @@
 Environments
 ============
 
-The :stable_gym:`Stable Gym package <>` provides a variety of environments for training and testing 
+The :stable_gym:`Stable Gym package <>` provides a variety of environments for training and testing
 :stable_learning_control:`(stable) reinforcement learning (RL) algorithms <>`.
 
 Biological environments
@@ -21,7 +21,7 @@ Gym environments that are based on Biological systems.
 Classic control environments
 ----------------------------
 
-Environments that are based on classical control problems or `classical control`_ 
+Environments that are based on classical control problems or `classical control`_
 environments found in the :gymnasium:`gymnasium <>` library.
 
 .. _`classical control`: https://gymnasium.farama.org/environments/classic_control
@@ -65,16 +65,7 @@ Robotics environment
     ./robotics/quadx_tracking_cost.rst
     ./robotics/quadx_waypoints_cost.rst
 
-.. attention::
-
-    To utilize the Quadrotor environments, it is essential to have the :pybullet:`PyBullet <>`
-    package installed with `numpy`_ support. To avoid potential issues, ensure that `numpy`_
-    is installed before adding the :stable_gym:`Stable Gym package <>`. Please refer to the
-    :PyFlyt:`PyFlyt <.html#installation>` documentation for more information.
-
-.. _`numpy`: https://numpy.org/
-
 .. note::
 
-    The ROS robotics environments of the Stable Gym package were moved into a separate package 
+    The ROS robotics environments of the Stable Gym package were moved into a separate package
     called :ros_gazebo_gym:`Ros Gazebo Gym <>`.

--- a/docs/source/envs/robotics/quadx_hover_cost.rst
+++ b/docs/source/envs/robotics/quadx_hover_cost.rst
@@ -4,5 +4,3 @@
 .. warning::
     This environment is new and has not been thoroughly tested. As a result it may contain bugs
     and the cost function might be updated in the future.
-
-.. _`numpy`: https://numpy.org/

--- a/docs/source/envs/robotics/quadx_hover_cost.rst
+++ b/docs/source/envs/robotics/quadx_hover_cost.rst
@@ -5,11 +5,4 @@
     This environment is new and has not been thoroughly tested. As a result it may contain bugs
     and the cost function might be updated in the future.
 
-.. attention::
-
-    To utilize this Quadrotor environments, it is essential to have the :pybullet:`PyBullet <>`
-    package installed with `numpy`_ support. To avoid potential issues, ensure that `numpy`_
-    is installed before adding the :stable_gym:`Stable Gym package <>`. Please refer to the
-    :PyFlyt:`PyFlyt <.html#installation>` documentation for more information.
-
 .. _`numpy`: https://numpy.org/

--- a/docs/source/envs/robotics/quadx_tracking_cost.rst
+++ b/docs/source/envs/robotics/quadx_tracking_cost.rst
@@ -4,5 +4,3 @@
 .. warning::
     This environment is new and has not been thoroughly tested. As a result it may contain bugs
     and the cost function might be updated in the future.
-
-.. _`numpy`: https://numpy.org/

--- a/docs/source/envs/robotics/quadx_tracking_cost.rst
+++ b/docs/source/envs/robotics/quadx_tracking_cost.rst
@@ -5,11 +5,4 @@
     This environment is new and has not been thoroughly tested. As a result it may contain bugs
     and the cost function might be updated in the future.
 
-.. attention::
-
-    To utilize this Quadrotor environments, it is essential to have the :pybullet:`PyBullet <>`
-    package installed with `numpy`_ support. To avoid potential issues, ensure that `numpy`_
-    is installed before adding the :stable_gym:`Stable Gym package <>`. Please refer to the
-    :PyFlyt:`PyFlyt <.html#installation>` documentation for more information.
-
 .. _`numpy`: https://numpy.org/

--- a/docs/source/envs/robotics/quadx_waypoints_cost.rst
+++ b/docs/source/envs/robotics/quadx_waypoints_cost.rst
@@ -4,5 +4,3 @@
 .. warning::
     This environment is new and has not been thoroughly tested. As a result it may contain bugs
     and the cost function might be updated in the future.
-
-.. _`numpy`: https://numpy.org/

--- a/docs/source/envs/robotics/quadx_waypoints_cost.rst
+++ b/docs/source/envs/robotics/quadx_waypoints_cost.rst
@@ -5,11 +5,4 @@
     This environment is new and has not been thoroughly tested. As a result it may contain bugs
     and the cost function might be updated in the future.
 
-.. attention::
-
-    To utilize this Quadrotor environments, it is essential to have the :pybullet:`PyBullet <>`
-    package installed with `numpy`_ support. To avoid potential issues, ensure that `numpy`_
-    is installed before adding the :stable_gym:`Stable Gym package <>`. Please refer to the
-    :PyFlyt:`PyFlyt <.html#installation>` documentation for more information.
-
 .. _`numpy`: https://numpy.org/

--- a/stable_gym/envs/robotics/__init__.py
+++ b/stable_gym/envs/robotics/__init__.py
@@ -16,23 +16,18 @@
 
 .. _`Pybullet`: https://pybullet.org/
 """
-import pybullet
-
 from stable_gym.envs.robotics.fetch.fetch_reach_cost.fetch_reach_cost import (
     FetchReachCost,
 )
 from stable_gym.envs.robotics.minitaur.minitaur_bullet_cost.minitaur_bullet_cost import (
     MinitaurBulletCost,
 )
-
-# TODO: Can be removed if https://github.com/jjshoots/PyFlyt/issues/1 is resolved.
-if pybullet.isNumpyEnabled():
-    from stable_gym.envs.robotics.quadrotor.quadx_hover_cost.quadx_hover_cost import (
-        QuadXHoverCost,
-    )
-    from stable_gym.envs.robotics.quadrotor.quadx_tracking_cost.quadx_tracking_cost import (
-        QuadXTrackingCost,
-    )
-    from stable_gym.envs.robotics.quadrotor.quadx_waypoints_cost.quadx_waypoints_cost import (
-        QuadXWaypointsCost,
-    )
+from stable_gym.envs.robotics.quadrotor.quadx_hover_cost.quadx_hover_cost import (
+    QuadXHoverCost,
+)
+from stable_gym.envs.robotics.quadrotor.quadx_tracking_cost.quadx_tracking_cost import (
+    QuadXTrackingCost,
+)
+from stable_gym.envs.robotics.quadrotor.quadx_waypoints_cost.quadx_waypoints_cost import (
+    QuadXWaypointsCost,
+)


### PR DESCRIPTION
This removes the Numpy warning on PyFlyt. I've fixed it on PyFlyt's end to still function without Numpy.
Given that the environments within Stable Gym do not use the camera components, building PyBullet with Numpy is probably not mission critical, so a warning stating so is maybe not necessary?
Lmk if you would prefer to have that warning.