### PR TITLE
fix(quadxwaypointscost): fix directional penalty and add extra step info keys

### DIFF
--- a/stable_gym/envs/robotics/quadrotor/quadx_waypoints_cost/README.md
+++ b/stable_gym/envs/robotics/quadrotor/quadx_waypoints_cost/README.md
@@ -40,6 +40,20 @@ Where:
 
 The health penalty is optional and can be disabled using the `include_health_penalty` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [QuadXWaypoints-v1](https://jjshoots.github.io/PyFlyt/documentation/gym_envs/quadx_envs/quadx_waypoints_env.html) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference that the quadrotor is tracking (i.e. the immediate waypoint).
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:QuadXWaypoints-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/tests/__snapshots__/test_quadx_waypoints_cost.ambr
+++ b/tests/__snapshots__/test_quadx_waypoints_cost.ambr
@@ -152,9 +152,14 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.143
   dict({
     'collision': False,
+    'cost_direction': 0.0,
+    'cost_distance': 0.1176939007526,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
+    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
+    'reference_error': array([-0.12150615,  0.79761319, -0.26641033]),
+    'state_of_interest': array([-3.56867320e-04, -1.16926617e-03,  9.35723347e-01]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.144
@@ -319,9 +324,14 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.192
   dict({
     'collision': False,
+    'cost_direction': 0.0,
+    'cost_distance': 0.1184372588129,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
+    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
+    'reference_error': array([-0.12040818,  0.79811885, -0.24778913]),
+    'state_of_interest': array([ 7.41108238e-04, -6.63602930e-04,  9.54344544e-01]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.193
@@ -489,9 +499,14 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.241
   dict({
     'collision': False,
+    'cost_direction': 0.0,
+    'cost_distance': 0.1194560838987,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
+    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
+    'reference_error': array([-0.11811294,  0.80260758, -0.20652661]),
+    'state_of_interest': array([0.00303635, 0.00382512, 0.99560706]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.242
@@ -656,9 +671,14 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.290
   dict({
     'collision': False,
+    'cost_direction': 0.0,
+    'cost_distance': 0.119940052153,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
+    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
+    'reference_error': array([-0.11495111,  0.80939908, -0.16370148]),
+    'state_of_interest': array([0.00619818, 0.01061663, 1.0384322 ]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.3
@@ -715,9 +735,14 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.45
   dict({
     'collision': False,
+    'cost_direction': 2.523376009453,
+    'cost_distance': 0.1188883459604,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
+    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
+    'reference_error': array([-0.12114929,  0.79878246, -0.23401123]),
+    'state_of_interest': array([-2.72890000e-09,  1.02375000e-08,  9.68122447e-01]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.46
@@ -871,7 +896,7 @@
   -0.2374694422034
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.91
-  0.1178975156052
+  0.1224165607462
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.92
   False
@@ -882,9 +907,14 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.94
   dict({
     'collision': False,
+    'cost_direction': 0.0045190451409,
+    'cost_distance': 0.1178975156052,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
+    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
+    'reference_error': array([-0.12117407,  0.7987328 , -0.25841114]),
+    'state_of_interest': array([-2.47790283e-05, -4.96531636e-05,  9.43722535e-01]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.95


### PR DESCRIPTION
This pull request fixes a bug when calculating the directional penalty. It also adds the `reference`, `state_of_interest` and `reference_error` to the info returned by the environment step and reset methods.
