### PR TITLE
feat(fetchreachcost): add reference info to step/reset return

### DIFF
--- a/stable_gym/envs/robotics/fetch/fetch_reach_cost/README.md
+++ b/stable_gym/envs/robotics/fetch/fetch_reach_cost/README.md
@@ -25,6 +25,20 @@ Where:
 *   $p$ - is the achieved goal position (i.e. the end-effector position in Cartesian space).
 *   $p_{goal}$ - is the desired goal position in Cartesian space.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [FetchReach-v2](https://robotics.farama.org/envs/fetch/reach/) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference position (x,y,z) that the FetchReach is tracking.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:FetchReachCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/robotics/fetch/fetch_reach_cost/fetch_reach_cost.py
+++ b/stable_gym/envs/robotics/fetch/fetch_reach_cost/fetch_reach_cost.py
@@ -132,6 +132,15 @@ class FetchReachCost(MujocoFetchReachEnv, utils.EzPickle):
 
         self.state = obs
 
+        # Update info dictionary.
+        info.update(
+            {
+                "reference": obs["desired_goal"],
+                "state_of_interest": obs["observation"][:3],
+                "reference_error": obs["observation"][:3] - obs["desired_goal"],
+            }
+        )
+
         return obs, self.cost(reward), terminated, truncated, info
 
     def reset(self, seed=None, options=None):
@@ -153,6 +162,15 @@ class FetchReachCost(MujocoFetchReachEnv, utils.EzPickle):
         obs, info = super().reset(seed=seed, options=options)
 
         self.state = obs["observation"]
+
+        # Update info dictionary.
+        info.update(
+            {
+                "reference": obs["desired_goal"],
+                "state_of_interest": obs["observation"][:3],
+                "reference_error": obs["observation"][:3] - obs["desired_goal"],
+            }
+        )
 
         return obs, info
 

--- a/tests/__snapshots__/test_fetch_reach_cost.ambr
+++ b/tests/__snapshots__/test_fetch_reach_cost.ambr
@@ -62,6 +62,9 @@
 # name: TestFetchReachCostEqual.test_snapshot.116
   dict({
     'is_success': 0.0,
+    'reference': array([1.42404184, 0.73076404, 0.64228632]),
+    'reference_error': array([-0.1037502 ,  0.03696915, -0.05933302]),
+    'state_of_interest': array([1.32029164, 0.76773319, 0.58295331]),
   })
 # ---
 # name: TestFetchReachCostEqual.test_snapshot.12
@@ -79,8 +82,8 @@
 # name: TestFetchReachCostEqual.test_snapshot.16
   dict({
     'reference': array([1.42404184, 0.73076404, 0.64228632]),
-    'reference_error': 3.0,
-    'state_of_interest': 1.341854859091886,
+    'reference_error': array([-0.08218698,  0.01833647, -0.10757912]),
+    'state_of_interest': array([1.34185486, 0.74910051, 0.5347072 ]),
   })
 # ---
 # name: TestFetchReachCostEqual.test_snapshot.17
@@ -149,6 +152,9 @@
 # name: TestFetchReachCostEqual.test_snapshot.36
   dict({
     'is_success': 0.0,
+    'reference': array([1.42404184, 0.73076404, 0.64228632]),
+    'reference_error': array([-0.06611585,  0.0145536 , -0.08569325]),
+    'state_of_interest': array([1.35792598, 0.74531764, 0.55659307]),
   })
 # ---
 # name: TestFetchReachCostEqual.test_snapshot.37
@@ -217,6 +223,9 @@
 # name: TestFetchReachCostEqual.test_snapshot.56
   dict({
     'is_success': 0.0,
+    'reference': array([1.42404184, 0.73076404, 0.64228632]),
+    'reference_error': array([-0.08924402,  0.04308588, -0.06787522]),
+    'state_of_interest': array([1.33479781, 0.77384992, 0.5744111 ]),
   })
 # ---
 # name: TestFetchReachCostEqual.test_snapshot.57
@@ -285,6 +294,9 @@
 # name: TestFetchReachCostEqual.test_snapshot.76
   dict({
     'is_success': 0.0,
+    'reference': array([1.42404184, 0.73076404, 0.64228632]),
+    'reference_error': array([-0.11442367,  0.04261431, -0.0745017 ]),
+    'state_of_interest': array([1.30961817, 0.77337835, 0.56778462]),
   })
 # ---
 # name: TestFetchReachCostEqual.test_snapshot.77
@@ -353,6 +365,9 @@
 # name: TestFetchReachCostEqual.test_snapshot.96
   dict({
     'is_success': 0.0,
+    'reference': array([1.42404184, 0.73076404, 0.64228632]),
+    'reference_error': array([-0.10781631,  0.06190539, -0.0790086 ]),
+    'state_of_interest': array([1.31622552, 0.79266943, 0.56327773]),
   })
 # ---
 # name: TestFetchReachCostEqual.test_snapshot.97


### PR DESCRIPTION
This commit adds the `reference`, `state_of_interest` and `reference_error` to the dictionary that
is returned by the step/reset methods of the FetchReachCost environment.
