### PR TITLE
docs: add missing step return info dict keys

### DIFF
--- a/stable_gym/envs/biological/oscillator/README.md
+++ b/stable_gym/envs/biological/oscillator/README.md
@@ -52,9 +52,6 @@ The info dictionary contains the following keys:
 *   **reference**: The set cart position reference.
 *   **state\_of\_interest**: The state that should track the reference (SOI).
 *   **reference\_error**: The error between SOI and the reference.
-*   **reference\_constraint\_position**: A user-specified constraint they want to watch.
-*   **reference\_constraint\_error**: The error between the SOI and the set reference constraint.
-*   **reference\_constraint\_violated**: Whether the reference constraint was violated.
 
 ## How to use
 

--- a/stable_gym/envs/mujoco/ant_cost/README.md
+++ b/stable_gym/envs/mujoco/ant_cost/README.md
@@ -41,6 +41,20 @@ Where:
 
 The control and health penalty are optional and can be disabled using the `include_ctrl_cost` and `include_health_penalty` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [Ant-v4](https://gymnasium.farama.org/environments/mujoco/ant) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:AntCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/half_cheetah_cost/README.md
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/README.md
@@ -40,6 +40,20 @@ Where:
 
 The control cost is optional and can be disabled using the `include_ctrl_cost` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [HalfCheetah-v4](https://gymnasium.farama.org/environments/mujoco/half_cheetah)  environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:HalfCheetahCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/hopper_cost/README.md
+++ b/stable_gym/envs/mujoco/hopper_cost/README.md
@@ -41,6 +41,20 @@ Where:
 
 The control and health penalty are optional and can be disabled using the `include_ctrl_cost` and `include_health_penalty` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [Hopper-v4](https://gymnasium.farama.org/environments/mujoco/hopper) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:HopperCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/humanoid_cost/README.md
+++ b/stable_gym/envs/mujoco/humanoid_cost/README.md
@@ -42,6 +42,20 @@ Where:
 
 The control and health penalty are optional and can be disabled using the `include_ctrl_cost` and `include_health_penalty` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [Humanoid-v4](https://gymnasium.farama.org/environments/mujoco/humanoid) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:HumanoidCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/swimmer_cost/README.md
+++ b/stable_gym/envs/mujoco/swimmer_cost/README.md
@@ -40,6 +40,20 @@ Where:
 
 The control cost is optional and can be disabled using the `include_ctrl_cost` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [Swimmer-v4](https://gymnasium.farama.org/environments/mujoco/swimmer) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:SwimmerCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/mujoco/walker2d_cost/README.md
+++ b/stable_gym/envs/mujoco/walker2d_cost/README.md
@@ -43,6 +43,20 @@ Where:
 
 The control and health penalty are optional and can be disabled using the `include_ctrl_cost` and `include_health_penalty` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [Walker2d-v4](https://gymnasium.farama.org/environments/mujoco/walker2d) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:Walker2dCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.

--- a/stable_gym/envs/robotics/minitaur/minitaur_bullet_cost/README.md
+++ b/stable_gym/envs/robotics/minitaur/minitaur_bullet_cost/README.md
@@ -69,6 +69,20 @@ Where:
 
 The energy, shake, drift, and health penalty are optional and can be disabled using the `include_energy_cost`, `include_shake_cost`, `include_drift_cost` and `include_health_penalty` environment arguments.
 
+## Environment step return
+
+In addition to the observations, the cost and a termination and truncation boolean, the environment also returns an info dictionary:
+
+```python
+[observation, cost, termination, truncation, info_dict]
+```
+
+Compared to the original [MinitaurBulletEnv-v0](https://github.com/bulletphysics/bullet3/blob/master/examples/pybullet/gym/pybullet_envs/bullet/minitaur_gym_env.py) environment, the following keys were added to this info dictionary:
+
+*   **reference**: The reference velocity.
+*   **state\_of\_interest**: The state that should track the reference (SOI).
+*   **reference\_error**: The error between SOI and the reference.
+
 ## How to use
 
 This environment is part of the [Stable Gym package](https://github.com/rickstaa/stable-gym). It is therefore registered as the `stable_gym:MinitaurBulletCost-v1` gymnasium environment when you import the Stable Gym package. If you want to use the environment in stand-alone mode, you can register it yourself.


### PR DESCRIPTION
This pull request adds some missing step return keys to the environment docs (i.e. `reference`,
`state_of_interest` and `reference_error`).
