### PR TITLE
test: decrease quadx snapshot precision

### DIFF
--- a/tests/__snapshots__/test_quadx_hover_cost.ambr
+++ b/tests/__snapshots__/test_quadx_hover_cost.ambr
@@ -1,165 +1,165 @@
 # serializer version: 1
 # name: TestQuadXHoverCostEqual.test_snapshot
-  -0.0055462600926
+  -0.00555
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.1
-  0.0026603582032
+  0.00266
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.10
-  -2.7289e-09
+  -0.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.100
-  -0.0527336655245
+  -0.05273
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.101
-  0.0160796483257
+  0.01608
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.102
-  0.0150332883709
+  0.01503
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.103
-  0.9983659678048
+  0.99837
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.104
-  0.0255841040446
+  0.02558
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.105
-  0.0257673178296
+  0.02577
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.106
-  0.7517916855545
+  0.75179
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.107
-  0.0013943159926
+  0.00139
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.108
-  0.0016747970575
+  0.00167
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.109
-  0.9597564148563
+  0.95976
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.11
-  1.02375e-08
+  0.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.110
-  0.9039312087065
+  0.90393
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.111
-  2.0279710262249
+  2.02797
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.112
-  -0.3555390745231
+  -0.35554
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.113
-  0.1817909774278
+  0.18179
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.114
-  0.1279109990085
+  0.12791
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.115
-  0.1453538153817
+  0.14535
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.116
-  0.2602182587865
+  0.26022
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.117
-  0.4227309790298
+  0.42273
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.118
-  0.1506388379522
+  0.15064
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.119
   False
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.12
-  0.9681224473745
+  0.96812
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.120
   False
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.121
   dict({
-    'angular_distance': 0.110336292034,
+    'angular_distance': 0.11034,
     'collision': False,
     'env_complete': False,
-    'linear_distance': 0.0403025459182,
+    'linear_distance': 0.0403,
     'out_of_bounds': False,
     'reference': array([0., 0., 1., 0., 0.]),
-    'reference_error': array([ 0.00139432,  0.0016748 , -0.04024359,  0.10506426, -0.03369865]),
-    'state_of_interest': array([ 0.00139432,  0.0016748 ,  0.95975641, -0.10506426,  0.03369865]),
+    'reference_error': array([ 0.00139,  0.00167, -0.04024,  0.10506, -0.0337 ]),
+    'state_of_interest': array([ 0.00139,  0.00167,  0.95976, -0.10506,  0.0337 ]),
   })
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.122
-  1.6785156035716
+  1.67852
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.123
-  -4.7688442123744
+  -4.76884
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.124
-  3.1750605172291
+  3.17506
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.125
-  -0.0384294204542
+  -0.03843
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.126
-  0.0085241954369
+  0.00852
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.127
-  0.0329118665708
+  0.03291
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.128
-  0.9986827958739
+  0.99868
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.129
-  0.0579519899337
+  0.05795
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.13
   0.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.130
-  0.072838812168
+  0.07284
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.131
-  0.9101003476983
+  0.9101
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.132
-  0.0027966981947
+  0.0028
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.133
-  0.0048391756589
+  0.00484
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.134
-  0.9797715041572
+  0.97977
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.135
-  0.3429663317734
+  0.34297
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.136
-  -2.7406170076915
+  -2.74062
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.137
-  2.0585673660378
+  2.05857
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.138
-  0.5053315192977
+  0.50533
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.139
-  0.5200128548787
+  0.52001
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.14
   0.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.140
-  0.3339532255999
+  0.33395
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.141
-  0.5919040563199
+  0.5919
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.142
-  0.5236632956297
+  0.52366
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.143
-  0.0997384372719
+  0.09974
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.144
   False
@@ -169,14 +169,14 @@
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.146
   dict({
-    'angular_distance': 0.0787519848344,
+    'angular_distance': 0.07875,
     'collision': False,
     'env_complete': False,
-    'linear_distance': 0.0209864524375,
+    'linear_distance': 0.02099,
     'out_of_bounds': False,
     'reference': array([0., 0., 1., 0., 0.]),
-    'reference_error': array([ 0.0027967 ,  0.00483918, -0.0202285 ,  0.07628505, -0.01955675]),
-    'state_of_interest': array([ 0.0027967 ,  0.00483918,  0.9797715 , -0.07628505,  0.01955675]),
+    'reference_error': array([ 0.0028 ,  0.00484, -0.02023,  0.07629, -0.01956]),
+    'state_of_interest': array([ 0.0028 ,  0.00484,  0.97977, -0.07629,  0.01956]),
   })
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.15
@@ -186,105 +186,103 @@
   0.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.17
-  0.0504498315889
+  0.05045
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.18
-  0.0511314130747
+  0.05113
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.19
-  0.0489284996549
+  0.04893
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.2
-  0.0014850074979
+  0.00149
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.20
-  0.0491534134335
+  0.04915
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.21
   dict({
-    'angular_distance': 0.0001994989326,
+    'angular_distance': 0.0002,
     'collision': False,
     'env_complete': False,
-    'linear_distance': 0.0318775526255,
+    'linear_distance': 0.03188,
     'out_of_bounds': False,
     'reference': array([0., 0., 1., 0., 0.]),
-    'reference_error': array([-2.72890000e-09,  1.02375000e-08, -3.18775526e-02,  1.99166961e-04,
-          1.15041579e-05]),
-    'state_of_interest': array([-2.72890000e-09,  1.02375000e-08,  9.68122447e-01, -1.99166961e-04,
-         -1.15041579e-05]),
+    'reference_error': array([-0.000e+00,  0.000e+00, -3.188e-02,  2.000e-04,  1.000e-05]),
+    'state_of_interest': array([-0.0000e+00,  0.0000e+00,  9.6812e-01, -2.0000e-04, -1.0000e-05]),
   })
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.22
-  2.735040642528
+  2.73504
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.23
-  -1.1522096441232
+  -1.15221
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.24
-  3.0068916952955
+  3.00689
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.25
-  0.0165307213117
+  0.01653
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.26
-  -0.0077771888074
+  -0.00778
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.27
-  0.0167294393779
+  0.01673
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.28
-  0.9996931411415
+  0.99969
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.29
-  -0.0119015956622
+  -0.0119
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.3
-  -9.95833836e-05
+  -0.0001
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.30
-  -0.0239866178159
+  -0.02399
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.31
-  -0.6864391289097
+  -0.68644
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.32
-  -4.6086366e-06
+  -0.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.33
-  -8.2299012e-06
+  -1e-05
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.34
-  0.9488315866091
+  0.94883
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.35
-  1.7213166190998
+  1.72132
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.36
-  -0.3840380893018
+  -0.38404
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.37
-  2.2531371815724
+  2.25314
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.38
-  0.5578944232475
+  0.55789
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.39
-  0.4152636366719
+  0.41526
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.4
-  -5.7537558e-06
+  -1e-05
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.40
-  0.4720171802264
+  0.47202
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.41
-  0.6176299184521
+  0.61763
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.42
-  0.6110930263573
+  0.61109
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.43
-  0.0877093393525
+  0.08771
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.44
   False
@@ -294,183 +292,180 @@
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.46
   dict({
-    'angular_distance': 0.0365409250922,
+    'angular_distance': 0.03654,
     'collision': False,
     'env_complete': False,
-    'linear_distance': 0.0511684142603,
+    'linear_distance': 0.05117,
     'out_of_bounds': False,
     'reference': array([0., 0., 1., 0., 0.]),
-    'reference_error': array([-4.60863660e-06, -8.22990120e-06, -5.11684134e-02, -3.28012151e-02,
-          1.61034000e-02]),
-    'state_of_interest': array([-4.60863660e-06, -8.22990120e-06,  9.48831587e-01,  3.28012151e-02,
-         -1.61034000e-02]),
+    'reference_error': array([-0.000e+00, -1.000e-05, -5.117e-02, -3.280e-02,  1.610e-02]),
+    'state_of_interest': array([-0.0000e+00, -1.0000e-05,  9.4883e-01,  3.2800e-02, -1.6100e-02]),
   })
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.47
-  -6.3347310686358
+  -6.33473
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.48
-  4.7753342794721
+  4.77533
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.49
-  1.2205149011511
+  1.22051
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.5
-  1.6838243e-05
+  2e-05
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.50
-  -0.0106037272637
+  -0.0106
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.51
-  0.0212832795302
+  0.02128
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.52
-  0.0513481434144
+  0.05135
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.53
-  0.9983976918786
+  0.9984
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.54
-  -0.0018326188579
+  -0.00183
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.55
-  -0.0238574120595
+  -0.02386
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.56
-  -0.217962246622
+  -0.21796
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.57
-  -0.0001558838749
+  -0.00016
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.58
-  -0.0004124952471
+  -0.00041
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.59
-  0.9379605368636
+  0.93796
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.6
-  0.9999999948833
+  1.0
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.60
-  -2.549858925073
+  -2.54986
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.61
-  2.9884233715703
+  2.98842
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.62
-  1.640789138667
+  1.64079
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.63
-  0.6288514442216
+  0.62885
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.64
-  0.7424261971998
+  0.74243
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.65
-  0.7429703122754
+  0.74297
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.66
-  0.5439640174849
+  0.54396
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.67
-  0.498729505904
+  0.49873
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.68
-  0.1096049181721
+  0.1096
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.69
   False
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.7
-  -8.9293644e-06
+  -1e-05
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.70
   False
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.71
   dict({
-    'angular_distance': 0.0475638878908,
+    'angular_distance': 0.04756,
     'collision': False,
     'env_complete': False,
-    'linear_distance': 0.0620410302813,
+    'linear_distance': 0.06204,
     'out_of_bounds': False,
     'reference': array([0., 0., 1., 0., 0.]),
-    'reference_error': array([-0.00015588, -0.0004125 , -0.06203946,  0.01900697, -0.04360113]),
-    'state_of_interest': array([-1.55883875e-04, -4.12495247e-04,  9.37960537e-01, -1.90069670e-02,
-          4.36011311e-02]),
+    'reference_error': array([-0.00016, -0.00041, -0.06204,  0.01901, -0.0436 ]),
+    'state_of_interest': array([-1.6000e-04, -4.1000e-04,  9.3796e-01, -1.9010e-02,  4.3600e-02]),
   })
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.72
-  -1.1476960240923
+  -1.1477
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.73
-  -3.1948499681914
+  -3.19485
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.74
-  -2.6575230680436
+  -2.65752
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.75
-  -0.0700819867092
+  -0.07008
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.76
-  0.0125502861371
+  0.01255
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.77
-  0.0355211072145
+  0.03552
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.78
-  0.9968296024893
+  0.99683
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.79
-  0.0261337952242
+  0.02613
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.8
-  0.0001527112002
+  0.00015
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.80
-  -0.0331935941958
+  -0.03319
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.81
-  0.4725679847222
+  0.47257
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.82
-  0.0002314260664
+  0.00023
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.83
-  -0.0005268208639
+  -0.00053
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.84
-  0.9420203026474
+  0.94202
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.85
-  -2.3366309591134
+  -2.33663
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.86
-  -0.3117343460441
+  -0.31173
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.87
-  -0.8117999558004
+  -0.8118
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.88
-  0.7414119910789
+  0.74141
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.89
-  0.5516333406708
+  0.55163
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.9
-  -0.7635167337801
+  -0.76352
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.90
-  0.8586115917293
+  0.85861
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.91
-  0.8183595082831
+  0.81836
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.92
-  0.7130720721537
+  0.71307
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.93
-  0.2005173379443
+  0.20052
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.94
   False
@@ -480,23 +475,22 @@
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.96
   dict({
-    'angular_distance': 0.1425347853673,
+    'angular_distance': 0.14253,
     'collision': False,
     'env_complete': False,
-    'linear_distance': 0.057982552577,
+    'linear_distance': 0.05798,
     'out_of_bounds': False,
     'reference': array([0., 0., 1., 0., 0.]),
-    'reference_error': array([ 0.00023143, -0.00052682, -0.0579797 ,  0.13934098, -0.03000427]),
-    'state_of_interest': array([ 2.31426066e-04, -5.26820864e-04,  9.42020303e-01, -1.39340979e-01,
-          3.00042747e-02]),
+    'reference_error': array([ 0.00023, -0.00053, -0.05798,  0.13934, -0.03   ]),
+    'state_of_interest': array([ 2.3000e-04, -5.3000e-04,  9.4202e-01, -1.3934e-01,  3.0000e-02]),
   })
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.97
-  0.942116505078
+  0.94212
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.98
-  2.7529356150198
+  2.75294
 # ---
 # name: TestQuadXHoverCostEqual.test_snapshot.99
-  -0.6367467168995
+  -0.63675
 # ---

--- a/tests/__snapshots__/test_quadx_tracking_cost.ambr
+++ b/tests/__snapshots__/test_quadx_tracking_cost.ambr
@@ -1,69 +1,69 @@
 # serializer version: 1
 # name: TestQuadXTrackingCostEqual.test_snapshot
-  -0.0055462600926
+  -0.00555
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.1
-  0.0026603582032
+  0.00266
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.10
-  -2.7289e-09
+  -0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.100
-  0.0002314260664
+  0.00023
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.101
-  -0.0005268208639
+  -0.00053
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.102
-  0.9420203026474
+  0.94202
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.103
-  -2.3366309591134
+  -2.33663
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.104
-  -0.3117343460441
+  -0.31173
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.105
-  -0.8117999558004
+  -0.8118
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.106
-  0.7414119910789
+  0.74141
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.107
-  0.5516333406708
+  0.55163
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.108
-  0.8586115917293
+  0.85861
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.109
-  0.8183595082831
+  0.81836
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.11
-  1.02375e-08
+  0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.110
-  0.7130720721537
+  0.71307
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.111
-  0.1175373974578
+  0.11754
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.112
-  -0.9930684569549
+  -0.99307
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.113
-  1.0117766126774
+  1.01178
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.114
-  -0.1173059713914
+  -0.11731
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.115
-  0.992541636091
+  0.99254
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.116
-  -0.06975631003
+  -0.06976
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.117
-  1.0018809974679
+  1.00188
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.118
   False
@@ -72,107 +72,107 @@
   False
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.12
-  0.9681224473745
+  0.96812
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.120
   dict({
     'collision': False,
     'env_complete': False,
     'out_of_bounds': False,
-    'reference': array([ 0.1175374 , -0.99306846,  1.01177661]),
-    'reference_error': array([-0.11730597,  0.99254164, -0.06975631]),
-    'state_of_interest': array([ 2.31426066e-04, -5.26820864e-04,  9.42020303e-01]),
+    'reference': array([ 0.11754, -0.99307,  1.01178]),
+    'reference_error': array([-0.11731,  0.99254, -0.06976]),
+    'state_of_interest': array([ 2.3000e-04, -5.3000e-04,  9.4202e-01]),
   })
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.121
-  0.942116505078
+  0.94212
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.122
-  2.7529356150198
+  2.75294
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.123
-  -0.6367467168995
+  -0.63675
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.124
-  -0.0527336655245
+  -0.05273
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.125
-  0.0160796483257
+  0.01608
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.126
-  0.0150332883709
+  0.01503
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.127
-  0.9983659678048
+  0.99837
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.128
-  0.0255841040446
+  0.02558
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.129
-  0.0257673178296
+  0.02577
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.13
   0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.130
-  0.7517916855545
+  0.75179
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.131
-  0.0013943159926
+  0.00139
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.132
-  0.0016747970575
+  0.00167
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.133
-  0.9597564148563
+  0.95976
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.134
-  0.9039312087065
+  0.90393
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.135
-  2.0279710262249
+  2.02797
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.136
-  -0.3555390745231
+  -0.35554
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.137
-  0.1817909774278
+  0.18179
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.138
-  0.1279109990085
+  0.12791
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.139
-  0.1453538153817
+  0.14535
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.14
   0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.140
-  0.2602182587865
+  0.26022
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.141
-  0.4227309790298
+  0.42273
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.142
-  0.1564344650402
+  0.15643
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.143
-  -0.9876883405951
+  -0.98769
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.144
-  1.0156976298823
+  1.0157
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.145
-  -0.1550401490476
+  -0.15504
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.146
-  0.9893631376527
+  0.98936
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.147
-  -0.055941215026
+  -0.05594
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.148
-  1.0029986468093
+  1.003
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.149
   False
@@ -188,103 +188,103 @@
     'collision': False,
     'env_complete': False,
     'out_of_bounds': False,
-    'reference': array([ 0.15643447, -0.98768834,  1.01569763]),
-    'reference_error': array([-0.15504015,  0.98936314, -0.05594122]),
-    'state_of_interest': array([0.00139432, 0.0016748 , 0.95975641]),
+    'reference': array([ 0.15643, -0.98769,  1.0157 ]),
+    'reference_error': array([-0.15504,  0.98936, -0.05594]),
+    'state_of_interest': array([0.00139, 0.00167, 0.95976]),
   })
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.152
-  1.6785156035716
+  1.67852
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.153
-  -4.7688442123744
+  -4.76884
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.154
-  3.1750605172291
+  3.17506
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.155
-  -0.0384294204542
+  -0.03843
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.156
-  0.0085241954369
+  0.00852
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.157
-  0.0329118665708
+  0.03291
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.158
-  0.9986827958739
+  0.99868
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.159
-  0.0579519899337
+  0.05795
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.16
   0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.160
-  0.072838812168
+  0.07284
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.161
-  0.9101003476983
+  0.9101
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.162
-  0.0027966981947
+  0.0028
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.163
-  0.0048391756589
+  0.00484
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.164
-  0.9797715041572
+  0.97977
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.165
-  0.3429663317734
+  0.34297
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.166
-  -2.7406170076915
+  -2.74062
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.167
-  2.0585673660378
+  2.05857
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.168
-  0.5053315192977
+  0.50533
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.169
-  0.5200128548787
+  0.52001
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.17
-  0.0504498315889
+  0.05045
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.170
-  0.3339532255999
+  0.33395
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.171
-  0.5919040563199
+  0.5919
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.172
-  0.5236632956297
+  0.52366
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.173
-  0.1950903220161
+  0.19509
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.174
-  -0.9807852804032
+  -0.98079
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.175
-  1.019614773932
+  1.01961
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.176
-  -0.1922936238214
+  -0.19229
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.177
-  0.9856244560621
+  0.98562
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.178
-  -0.0398432697747
+  -0.03984
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.179
-  1.0049974588507
+  1.005
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.18
-  0.0511314130747
+  0.05113
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.180
   False
@@ -297,19 +297,19 @@
     'collision': False,
     'env_complete': False,
     'out_of_bounds': False,
-    'reference': array([ 0.19509032, -0.98078528,  1.01961477]),
-    'reference_error': array([-0.19229362,  0.98562446, -0.03984327]),
-    'state_of_interest': array([0.0027967 , 0.00483918, 0.9797715 ]),
+    'reference': array([ 0.19509, -0.98079,  1.01961]),
+    'reference_error': array([-0.19229,  0.98562, -0.03984]),
+    'state_of_interest': array([0.0028 , 0.00484, 0.97977]),
   })
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.19
-  0.0489284996549
+  0.04893
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.2
-  0.0014850074979
+  0.00149
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.20
-  0.0491534134335
+  0.04915
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.21
   0.0
@@ -321,13 +321,13 @@
   1.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.24
-  -2.7289e-09
+  -0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.25
-  1.0000000102375
+  1.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.26
-  -0.0318775526255
+  -0.03188
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.27
   dict({
@@ -335,102 +335,102 @@
     'env_complete': False,
     'out_of_bounds': False,
     'reference': array([ 0., -1.,  1.]),
-    'reference_error': array([-2.72890000e-09,  1.00000001e+00, -3.18775526e-02]),
-    'state_of_interest': array([-2.72890000e-09,  1.02375000e-08,  9.68122447e-01]),
+    'reference_error': array([-0.     ,  1.     , -0.03188]),
+    'state_of_interest': array([-0.     ,  0.     ,  0.96812]),
   })
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.28
-  2.735040642528
+  2.73504
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.29
-  -1.1522096441232
+  -1.15221
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.3
-  -9.95833836e-05
+  -0.0001
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.30
-  3.0068916952955
+  3.00689
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.31
-  0.0165307213117
+  0.01653
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.32
-  -0.0077771888074
+  -0.00778
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.33
-  0.0167294393779
+  0.01673
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.34
-  0.9996931411415
+  0.99969
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.35
-  -0.0119015956622
+  -0.0119
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.36
-  -0.0239866178159
+  -0.02399
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.37
-  -0.6864391289097
+  -0.68644
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.38
-  -4.6086366e-06
+  -0.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.39
-  -8.2299012e-06
+  -1e-05
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.4
-  -5.7537558e-06
+  -1e-05
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.40
-  0.9488315866091
+  0.94883
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.41
-  1.7213166190998
+  1.72132
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.42
-  -0.3840380893018
+  -0.38404
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.43
-  2.2531371815724
+  2.25314
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.44
-  0.5578944232475
+  0.55789
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.45
-  0.4152636366719
+  0.41526
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.46
-  0.4720171802264
+  0.47202
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.47
-  0.6176299184521
+  0.61763
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.48
-  0.6110930263573
+  0.61109
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.49
-  0.0392598157591
+  0.03926
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.5
-  1.6838243e-05
+  2e-05
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.50
-  -0.9992290362407
+  -0.99923
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.51
-  1.003926829328
+  1.00393
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.52
-  -0.0392644243957
+  -0.03926
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.53
-  0.9992208063395
+  0.99922
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.54
-  -0.0550952427189
+  -0.0551
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.55
-  1.0015085624272
+  1.00151
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.56
   False
@@ -443,103 +443,103 @@
     'collision': False,
     'env_complete': False,
     'out_of_bounds': False,
-    'reference': array([ 0.03925982, -0.99922904,  1.00392683]),
-    'reference_error': array([-0.03926442,  0.99922081, -0.05509524]),
-    'state_of_interest': array([-4.60863660e-06, -8.22990120e-06,  9.48831587e-01]),
+    'reference': array([ 0.03926, -0.99923,  1.00393]),
+    'reference_error': array([-0.03926,  0.99922, -0.0551 ]),
+    'state_of_interest': array([-0.0000e+00, -1.0000e-05,  9.4883e-01]),
   })
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.59
-  -6.3347310686358
+  -6.33473
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.6
-  0.9999999948833
+  1.0
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.60
-  4.7753342794721
+  4.77533
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.61
-  1.2205149011511
+  1.22051
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.62
-  -0.0106037272637
+  -0.0106
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.63
-  0.0212832795302
+  0.02128
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.64
-  0.0513481434144
+  0.05135
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.65
-  0.9983976918786
+  0.9984
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.66
-  -0.0018326188579
+  -0.00183
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.67
-  -0.0238574120595
+  -0.02386
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.68
-  -0.217962246622
+  -0.21796
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.69
-  -0.0001558838749
+  -0.00016
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.7
-  -8.9293644e-06
+  -1e-05
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.70
-  -0.0004124952471
+  -0.00041
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.71
-  0.9379605368636
+  0.93796
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.72
-  -2.549858925073
+  -2.54986
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.73
-  2.9884233715703
+  2.98842
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.74
-  1.640789138667
+  1.64079
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.75
-  0.6288514442216
+  0.62885
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.76
-  0.7424261971998
+  0.74243
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.77
-  0.7429703122754
+  0.74297
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.78
-  0.5439640174849
+  0.54396
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.79
-  0.498729505904
+  0.49873
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.8
-  0.0001527112002
+  0.00015
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.80
-  0.0784590957278
+  0.07846
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.81
-  -0.9969173337331
+  -0.99692
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.82
-  1.0078526897695
+  1.00785
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.83
-  -0.0786149796028
+  -0.07861
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.84
-  0.9965048384861
+  0.9965
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.85
-  -0.0698921529059
+  -0.06989
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.86
-  1.0020414767773
+  1.00204
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.87
   False
@@ -552,41 +552,41 @@
     'collision': False,
     'env_complete': False,
     'out_of_bounds': False,
-    'reference': array([ 0.0784591 , -0.99691733,  1.00785269]),
-    'reference_error': array([-0.07861498,  0.99650484, -0.06989215]),
-    'state_of_interest': array([-1.55883875e-04, -4.12495247e-04,  9.37960537e-01]),
+    'reference': array([ 0.07846, -0.99692,  1.00785]),
+    'reference_error': array([-0.07861,  0.9965 , -0.06989]),
+    'state_of_interest': array([-1.6000e-04, -4.1000e-04,  9.3796e-01]),
   })
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.9
-  -0.7635167337801
+  -0.76352
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.90
-  -1.1476960240923
+  -1.1477
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.91
-  -3.1948499681914
+  -3.19485
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.92
-  -2.6575230680436
+  -2.65752
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.93
-  -0.0700819867092
+  -0.07008
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.94
-  0.0125502861371
+  0.01255
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.95
-  0.0355211072145
+  0.03552
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.96
-  0.9968296024893
+  0.99683
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.97
-  0.0261337952242
+  0.02613
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.98
-  -0.0331935941958
+  -0.03319
 # ---
 # name: TestQuadXTrackingCostEqual.test_snapshot.99
-  0.4725679847222
+  0.47257
 # ---

--- a/tests/__snapshots__/test_quadx_waypoints_cost.ambr
+++ b/tests/__snapshots__/test_quadx_waypoints_cost.ambr
@@ -1,147 +1,147 @@
 # serializer version: 1
 # name: TestQuadXWaypointsCostEqual.test_snapshot
-  -0.0055462600926
+  -0.006
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.1
-  0.0026603582032
+  0.003
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.10
-  -2.7289e-09
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.100
-  0.0566030635871
+  0.057
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.101
-  0.997329550832
+  0.997
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.102
-  -0.0151634063152
+  -0.015
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.103
-  -0.0478104861334
+  -0.048
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.104
-  0.0481746120429
+  0.048
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.105
-  -0.0003568673201
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.106
-  -0.0011692661657
+  -0.001
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.107
-  0.9357233470676
+  0.936
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.108
-  -2.549858925073
+  -2.55
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.109
-  2.9884233715703
+  2.988
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.11
-  1.02375e-08
+  0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.110
-  1.640789138667
+  1.641
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.111
-  0.6288514442216
+  0.629
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.112
-  0.4872928725352
+  0.487
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.113
-  0.6669766880741
+  0.667
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.114
-  0.8324039698305
+  0.832
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.115
-  0.5084281789725
+  0.508
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.116
-  0.1211492872657
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.117
-  -0.7987824538961
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.118
-  1.2021336783065
+  1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.119
-  0.3644446074751
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.12
-  0.9681224473745
+  0.968
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.120
-  -0.1472730130272
+  -0.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.121
-  2.5461881593664
+  2.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.122
-  -1.445466799879
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.123
-  1.7789477326785
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.124
-  0.1606977145595
+  0.161
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.125
-  1.3427045556727
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.126
-  3.9111333860045
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.127
-  0.9534036426416
+  0.953
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.128
-  0.0140759759252
+  0.014
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.129
-  -0.8213880819595
+  -0.821
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.13
   0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.130
-  0.2169066461662
+  0.217
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.131
-  0.2364406065455
+  0.236
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.132
-  -0.2875508483503
+  -0.288
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.133
-  1.6153741615185
+  1.615
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.134
-  -1.1831856441942
+  -1.183
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.135
-  1.9795060463598
+  1.98
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.136
-  -0.73447363574
+  -0.734
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.137
-  1.7638800814021
+  1.764
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.138
-  3.723016888843
+  3.723
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.139
-  0.3716327821708
+  0.372
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.14
   0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.140
-  0.1176939007526
+  0.118
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.141
   False
@@ -153,167 +153,167 @@
   dict({
     'collision': False,
     'cost_direction': 0.0,
-    'cost_distance': 0.1176939007526,
+    'cost_distance': 0.118,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
-    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
-    'reference_error': array([-0.12150615,  0.79761319, -0.26641033]),
-    'state_of_interest': array([-3.56867320e-04, -1.16926617e-03,  9.35723347e-01]),
+    'reference': array([ 0.121, -0.799,  1.202]),
+    'reference_error': array([-0.122,  0.798, -0.266]),
+    'state_of_interest': array([-0.   , -0.001,  0.936]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.144
-  -2.003269192405
+  -2.003
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.145
-  -0.5348903436684
+  -0.535
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.146
-  -2.363649602021
+  -2.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.147
-  -0.0605195766159
+  -0.061
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.148
-  0.0099068422746
+  0.01
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.149
-  0.0464569713232
+  0.046
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.15
   0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.150
-  0.997036100218
+  0.997
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.151
-  0.0415108512834
+  0.042
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.152
-  -0.0469101224366
+  -0.047
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.153
-  1.0088456617315
+  1.009
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.154
-  0.0007411082375
+  0.001
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.155
-  -0.0006636029297
+  -0.001
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.156
-  0.9543445440036
+  0.954
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.157
-  -2.3366309591134
+  -2.337
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.158
-  -0.3117343460441
+  -0.312
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.159
-  -0.8117999558004
+  -0.812
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.16
   0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.160
-  0.7414119910789
+  0.741
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.161
-  0.6942378337572
+  0.694
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.162
-  0.7103581813806
+  0.71
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.163
-  0.5827819616312
+  0.583
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.164
-  0.9415111785722
+  0.942
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.165
-  0.1211492872657
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.166
-  -0.7987824538961
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.167
-  1.2021336783065
+  1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.168
-  0.3644446074751
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.169
-  -0.1472730130272
+  -0.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.17
-  0.0504498315889
+  0.05
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.170
-  2.5461881593664
+  2.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.171
-  -1.445466799879
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.172
-  1.7789477326785
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.173
-  0.1606977145595
+  0.161
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.174
-  1.3427045556727
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.175
-  3.9111333860045
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.176
-  0.9534036426416
+  0.953
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.177
-  0.0405968515546
+  0.041
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.178
-  -0.8298013902216
+  -0.83
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.179
-  0.1505750090606
+  0.151
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.18
-  0.0511314130747
+  0.051
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.180
-  0.3082583782816
+  0.308
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.181
-  -0.3696707773745
+  -0.37
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.182
-  1.5671824842157
+  1.567
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.183
-  -1.2568135851224
+  -1.257
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.184
-  1.9896494291522
+  1.99
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.185
-  -0.5917126587601
+  -0.592
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.186
-  1.693623847627
+  1.694
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.187
-  3.7404428286573
+  3.74
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.188
-  0.4937085886203
+  0.494
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.189
-  0.1184372588129
+  0.118
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.19
-  0.0489284996549
+  0.049
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.190
   False
@@ -325,173 +325,173 @@
   dict({
     'collision': False,
     'cost_direction': 0.0,
-    'cost_distance': 0.1184372588129,
+    'cost_distance': 0.118,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
-    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
-    'reference_error': array([-0.12040818,  0.79811885, -0.24778913]),
-    'state_of_interest': array([ 7.41108238e-04, -6.63602930e-04,  9.54344544e-01]),
+    'reference': array([ 0.121, -0.799,  1.202]),
+    'reference_error': array([-0.12 ,  0.798, -0.248]),
+    'state_of_interest': array([ 0.001, -0.001,  0.954]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.193
-  0.1911520897641
+  0.191
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.194
-  1.1466693704246
+  1.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.195
-  0.2337642432678
+  0.234
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.196
-  -0.099443112432
+  -0.099
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.197
-  0.046537264487
+  0.047
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.198
-  0.0317405203641
+  0.032
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.199
-  0.9934474771073
+  0.993
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.2
-  0.0014850074979
+  0.001
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.20
-  0.0491534134335
+  0.049
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.200
-  -0.038979904638
+  -0.039
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.201
-  -0.0907911324852
+  -0.091
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.202
-  1.245021382797
+  1.245
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.203
-  0.0030363505142
+  0.003
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.204
-  0.0038251236794
+  0.004
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.205
-  0.9956070649202
+  0.996
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.206
-  0.9039312087065
+  0.904
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.207
-  2.0279710262249
+  2.028
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.208
-  -0.3555390745231
+  -0.356
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.209
-  0.1817909774278
+  0.182
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.21
-  0.1211492872657
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.210
-  0.11848203488
+  0.118
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.211
-  0.2835983968634
+  0.284
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.212
-  0.3269457688406
+  0.327
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.213
-  0.1190243096451
+  0.119
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.214
-  0.1211492872657
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.215
-  -0.7987824538961
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.216
-  1.2021336783065
+  1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.217
-  0.3644446074751
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.218
-  -0.1472730130272
+  -0.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.219
-  2.5461881593664
+  2.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.22
-  -0.7987824538961
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.220
-  -1.445466799879
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.221
-  1.7789477326785
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.222
-  0.1606977145595
+  0.161
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.223
-  1.3427045556727
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.224
-  3.9111333860045
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.225
-  0.9534036426416
+  0.953
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.226
-  0.0537753070258
+  0.054
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.227
-  -0.8338545560388
+  -0.834
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.228
-  0.0507703375423
+  0.051
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.229
-  0.1978217409881
+  0.198
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.23
-  1.2021336783065
+  1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.230
-  -0.4757302990557
+  -0.476
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.231
-  1.5140328751128
+  1.514
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.232
-  -1.2613218659925
+  -1.261
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.233
-  2.003691895554
+  2.004
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.234
-  -0.5835933644749
+  -0.584
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.235
-  1.5455850828757
+  1.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.236
-  3.7334853852262
+  3.733
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.237
-  0.8577899017205
+  0.858
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.238
-  0.1194560838987
+  0.119
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.239
   False
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.24
-  0.3644446074751
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.240
   False
@@ -500,164 +500,164 @@
   dict({
     'collision': False,
     'cost_direction': 0.0,
-    'cost_distance': 0.1194560838987,
+    'cost_distance': 0.119,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
-    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
-    'reference_error': array([-0.11811294,  0.80260758, -0.20652661]),
-    'state_of_interest': array([0.00303635, 0.00382512, 0.99560706]),
+    'reference': array([ 0.121, -0.799,  1.202]),
+    'reference_error': array([-0.118,  0.803, -0.207]),
+    'state_of_interest': array([0.003, 0.004, 0.996]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.242
-  0.3261134004272
+  0.326
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.243
-  -5.3531270252004
+  -5.353
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.244
-  2.8602716441211
+  2.86
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.245
-  -0.0755537881301
+  -0.076
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.246
-  0.0050100640503
+  0.005
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.247
-  0.0630669867875
+  0.063
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.248
-  0.9951326944357
+  0.995
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.249
-  0.1157054415766
+  0.116
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.25
-  -0.1472730130272
+  -0.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.250
-  0.0211411546329
+  0.021
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.251
-  1.4175145724301
+  1.418
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.252
-  0.0061981769227
+  0.006
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.253
-  0.0106166275622
+  0.011
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.254
-  1.0384321978419
+  1.038
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.255
-  0.3429663317734
+  0.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.256
-  -2.7406170076915
+  -2.741
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.257
-  2.0585673660378
+  2.059
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.258
-  0.5053315192977
+  0.505
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.259
-  0.4677330343432
+  0.468
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.26
-  2.5461881593664
+  2.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.260
-  0.5186734203071
+  0.519
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.261
-  0.3977285127317
+  0.398
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.262
-  0.6174793453242
+  0.617
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.263
-  0.1211492872657
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.264
-  -0.7987824538961
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.265
-  1.2021336783065
+  1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.266
-  0.3644446074751
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.267
-  -0.1472730130272
+  -0.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.268
-  2.5461881593664
+  2.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.269
-  -1.445466799879
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.27
-  -1.445466799879
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.270
-  1.7789477326785
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.271
-  0.1606977145595
+  0.161
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.272
-  1.3427045556727
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.273
-  3.9111333860045
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.274
-  0.9534036426416
+  0.953
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.275
-  0.009855488342
+  0.01
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.276
-  -0.8327480713732
+  -0.833
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.277
-  0.0396525473922
+  0.04
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.278
-  0.3062767169055
+  0.306
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.279
-  -0.4258409837829
+  -0.426
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.28
-  1.7789477326785
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.280
-  1.466782776124
+  1.467
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.281
-  -1.2023050785441
+  -1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.282
-  2.0488197688012
+  2.049
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.283
-  -0.6012852720746
+  -0.601
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.284
-  1.8141057905486
+  1.814
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.285
-  3.6689193936408
+  3.669
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.286
-  0.5055302188716
+  0.506
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.287
-  0.119940052153
+  0.12
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.288
   False
@@ -666,237 +666,237 @@
   False
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.29
-  0.1606977145595
+  0.161
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.290
   dict({
     'collision': False,
     'cost_direction': 0.0,
-    'cost_distance': 0.119940052153,
+    'cost_distance': 0.12,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
-    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
-    'reference_error': array([-0.11495111,  0.80939908, -0.16370148]),
-    'state_of_interest': array([0.00619818, 0.01061663, 1.0384322 ]),
+    'reference': array([ 0.121, -0.799,  1.202]),
+    'reference_error': array([-0.115,  0.809, -0.164]),
+    'state_of_interest': array([0.006, 0.011, 1.038]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.3
-  -9.95833836e-05
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.30
-  1.3427045556727
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.31
-  3.9111333860045
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.32
-  0.9534036426416
+  0.953
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.33
-  0.1211250809183
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.34
-  -0.7988331348868
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.35
-  0.2338507409767
+  0.234
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.36
-  0.3644578044837
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.37
-  -0.1475995916067
+  -0.148
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.38
-  1.5780321536525
+  1.578
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.39
-  -1.4454161742302
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.4
-  -5.7537558e-06
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.40
-  1.7791571750641
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.41
-  -0.8070537712536
+  -0.807
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.42
-  1.3428361059333
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.43
-  3.9110910114443
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.44
-  -0.0139552931025
+  -0.014
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.45
   dict({
     'collision': False,
-    'cost_direction': 2.523376009453,
-    'cost_distance': 0.1188883459604,
+    'cost_direction': 2.523,
+    'cost_distance': 0.119,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
-    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
-    'reference_error': array([-0.12114929,  0.79878246, -0.23401123]),
-    'state_of_interest': array([-2.72890000e-09,  1.02375000e-08,  9.68122447e-01]),
+    'reference': array([ 0.121, -0.799,  1.202]),
+    'reference_error': array([-0.121,  0.799, -0.234]),
+    'state_of_interest': array([-0.   ,  0.   ,  0.968]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.46
-  2.5478470867227
+  2.548
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.47
-  -0.7396654023497
+  -0.74
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.48
-  3.5389653089522
+  3.539
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.49
-  0.0276203813396
+  0.028
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.5
-  1.6838243e-05
+  0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.50
-  -0.0114764426365
+  -0.011
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.51
-  0.0313232521802
+  0.031
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.52
-  0.9990616896228
+  0.999
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.53
-  -0.0179929597137
+  -0.018
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.54
-  -0.0382780397242
+  -0.038
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.55
-  -0.5856379443116
+  -0.586
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.56
-  -2.47790283e-05
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.57
-  -4.96531636e-05
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.58
-  0.9437225352086
+  0.944
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.59
-  1.7213166190998
+  1.721
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.6
-  0.9999999948833
+  1.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.60
-  -0.3840380893018
+  -0.384
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.61
-  2.2531371815724
+  2.253
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.62
-  0.5578944232475
+  0.558
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.63
-  0.5634226446243
+  0.563
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.64
-  0.5577363768638
+  0.558
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.65
-  0.4727662639824
+  0.473
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.66
-  0.5956197821663
+  0.596
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.67
-  0.1211492872657
+  0.121
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.68
-  -0.7987824538961
+  -0.799
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.69
-  1.2021336783065
+  1.202
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.7
-  -8.9293644e-06
+  -0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.70
-  0.3644446074751
+  0.364
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.71
-  -0.1472730130272
+  -0.147
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.72
-  2.5461881593664
+  2.546
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.73
-  -1.445466799879
+  -1.445
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.74
-  1.7789477326785
+  1.779
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.75
-  0.1606977145595
+  0.161
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.76
-  1.3427045556727
+  1.343
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.77
-  3.9111333860045
+  3.911
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.78
-  0.9534036426416
+  0.953
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.79
-  0.0777927217032
+  0.078
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.8
-  0.0001527112002
+  0.0
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.80
-  -0.7895319521144
+  -0.79
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.81
-  0.3000352466392
+  0.3
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.82
-  0.3940566197687
+  0.394
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.83
-  -0.0824659504568
+  -0.082
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.84
-  1.6001023327984
+  1.6
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.85
-  -1.3513200169051
+  -1.351
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.86
-  1.8215240787959
+  1.822
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.87
-  -0.8504389728283
+  -0.85
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.88
-  1.5822920371953
+  1.582
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.89
-  3.8131782975666
+  3.813
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.9
-  -0.7635167337801
+  -0.764
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.90
-  -0.2374694422034
+  -0.237
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.91
-  0.1224165607462
+  0.122
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.92
   False
@@ -907,28 +907,28 @@
 # name: TestQuadXWaypointsCostEqual.test_snapshot.94
   dict({
     'collision': False,
-    'cost_direction': 0.0045190451409,
-    'cost_distance': 0.1178975156052,
+    'cost_direction': 0.005,
+    'cost_distance': 0.118,
     'env_complete': False,
     'num_targets_reached': 0,
     'out_of_bounds': False,
-    'reference': array([ 0.12114929, -0.79878245,  1.20213368]),
-    'reference_error': array([-0.12117407,  0.7987328 , -0.25841114]),
-    'state_of_interest': array([-2.47790283e-05, -4.96531636e-05,  9.43722535e-01]),
+    'reference': array([ 0.121, -0.799,  1.202]),
+    'reference_error': array([-0.121,  0.799, -0.258]),
+    'state_of_interest': array([-0.   , -0.   ,  0.944]),
   })
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.95
-  -5.8867861959302
+  -5.887
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.96
-  3.2724452556146
+  3.272
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.97
-  0.3536958416912
+  0.354
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.98
-  -0.0331812069052
+  -0.033
 # ---
 # name: TestQuadXWaypointsCostEqual.test_snapshot.99
-  0.0320759682328
+  0.032
 # ---

--- a/tests/test_quadx_hover_cost.py
+++ b/tests/test_quadx_hover_cost.py
@@ -11,7 +11,7 @@ from stable_gym.common.utils import change_precision
 
 gym.logger.set_level(ERROR)
 
-PRECISION = 13
+PRECISION = 5
 
 
 class TestQuadXHoverCostEqual:

--- a/tests/test_quadx_tracking_cost.py
+++ b/tests/test_quadx_tracking_cost.py
@@ -11,7 +11,7 @@ from stable_gym.common.utils import change_precision
 
 gym.logger.set_level(ERROR)
 
-PRECISION = 13
+PRECISION = 5
 
 
 class TestQuadXTrackingCostEqual:

--- a/tests/test_quadx_waypoints_cost.py
+++ b/tests/test_quadx_waypoints_cost.py
@@ -11,7 +11,7 @@ from stable_gym.common.utils import change_precision
 
 gym.logger.set_level(ERROR)
 
-PRECISION = 13
+PRECISION = 3
 
 
 class TestQuadXWaypointsCostEqual:


### PR DESCRIPTION
This pull request decreases the snapshot test precision of the QuadCopter environments. This was done since they are not deterministic when running on different hardware (e.g. GitHub servers).
