### PR TITLE
docs: add ros-gazebo-gym positive reward comment

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,7 @@ extlinks = {
     "gymnasium": ("https://gymnasium.farama.org/%s", None),
     "gymnasium-robotics": ("https://robotics.farama.org/%s", None),
     "PyFlyt": ("https://jjshoots.github.io/PyFlyt/documentation%s", None),
-    "stable_learning_control": (
+    "stable-learning-control": (
         "https://github.com/rickstaa/stable-learning-control/%s",
         None,
     ),

--- a/docs/source/envs/envs.rst
+++ b/docs/source/envs/envs.rst
@@ -5,7 +5,7 @@ Environments
 ============
 
 The :stable-gym:`Stable Gym package <>` provides a variety of environments for training and testing
-:stable_learning_control:`(stable) reinforcement learning (RL) algorithms <>`.
+:stable-learning-control:`(stable) reinforcement learning (RL) algorithms <>`.
 
 Biological environments
 -----------------------
@@ -66,5 +66,7 @@ Robotics environment
     ./robotics/quadx_waypoints_cost.rst
 
 .. note::
-    The ROS robotics environments of the Stable Gym package were moved into a separate package
-    called :ros-gazebo-gym:`Ros Gazebo Gym <>`.
+    The ROS robotic environments from the Stable Gym package have been relocated to a
+    distinct package known as :ros-gazebo-gym:`Ros Gazebo Gym <>`. When integrating this package with 
+    stable RL agents, such as those available in the :stable-learning-control:`Stable Learning Control package <>`, 
+    it's crucial to configure the ``positive_reward`` argument as ``True``.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,9 +14,9 @@ Welcome to Stable Gym's documentation
 
 The :stable-gym:`Stable Gym <>` package contains several :gymnasium:`gymnasium environments <>` 
 with cost functions compatible with (stable) RL agents. It was initially created for the stable RL 
-algorithms in the :stable_learning_control:`Stable Learning Control <>` package but can be 
+algorithms in the :stable-learning-control:`Stable Learning Control <>` package but can be 
 used with any RL agent requiring a **positive definite cost function**. For more information about stable
-RL agents see the :stable_learning_control:`Stable Learning Control documentation <>`.
+RL agents see the :stable-learning-control:`Stable Learning Control documentation <>`.
 
 Contents
 ========


### PR DESCRIPTION
This commit adds a comment that lets people know that they have to set
the ``positive_reward`` argument to ``True`` if they want to use the
environments in the
[ros-gazebo-gym](https://github.com/rickstaa/ros-gazebo-gym) package
with the stable RL agents in the
[stable-learning-control](https://github.com/rickstaa/stable-learning-control)
package.
