### PR TITLE
docs(halfCheetahCost): add Han et al. 2020 codebase difference comment

### DIFF
--- a/stable_gym/envs/mujoco/half_cheetah_cost/README.md
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/README.md
@@ -12,6 +12,10 @@ An actuated 8-jointed half cheetah. This environment corresponds to the [HalfChe
 
 The rest of the environment is the same as the original HalfCheetah environment. Below, the modified cost is described. For more information about the environment (e.g. observation space, action space, episode termination, etc.), please refer to the [gymnasium library](https://gymnasium.farama.org/environments/mujoco/half_cheetah/).
 
+:::{important}
+The original code from [Han et al. 2020](https://github.com/hithmh/Actor-critic-with-stability-guarantee/blob/8a90574fae550e98a9b628bbead6da7f91a51fff/ENV/env/mujoco/half_cheetah_cost.py#L23) terminates the episode if the cheetah's back thigh angle exceeds $0.5 \pi$ or falls below $-0.5 \pi$. This condition, not mentioned in the paper, is not implemented here as it's not part of the original environment.
+:::
+
 ## Observation space
 
 The original observation space of the [HalfCheetah-v4](https://gymnasium.farama.org/environments/mujoco/half_cheetah) environment contains all eight motors' angles, velocities and torques. In this modified version, the observation space has been extended to add three additional observations:

--- a/stable_gym/envs/mujoco/half_cheetah_cost/half_cheetah_cost.py
+++ b/stable_gym/envs/mujoco/half_cheetah_cost/half_cheetah_cost.py
@@ -39,6 +39,9 @@ class HalfCheetahCost(HalfCheetahEnv, utils.EzPickle):
         (e.g. observation space, action space, episode termination, etc.), please refer
         to the :gymnasium:`gymnasium library <environments/mujoco/half_cheetah>`.
 
+        .. important::
+            The original code from `Han et al. 2020 <han_code_>`_ terminates the episode if the cheetah's back thigh angle exceeds :math:`0.5 \pi` or falls below :math:`-0.5 \pi`. This condition, not mentioned in the paper, is not implemented here as it's not part of the original environment.
+
     Modified cost:
         A cost, computed using the :meth:`HalfCheetahCost.cost` method, is given for each
         simulation step, including the terminal step. This cost is defined as the error
@@ -65,6 +68,8 @@ class HalfCheetahCost(HalfCheetahEnv, utils.EzPickle):
         dt (float): The environment step size. Also available as :attr:`.tau`.
         reference_forward_velocity (float): The forward velocity that the agent should
             try to track.
+
+    .. _`han_code`: https://github.com/hithmh/Actor-critic-with-stability-guarantee/blob/8a90574fae550e98a9b628bbead6da7f91a51fff/ENV/env/mujoco/half_cheetah_cost.py#L23
     """  # noqa: E501
 
     def __init__(


### PR DESCRIPTION
This pull request adds a small comment to the HalfCheetahCost environment that explains how our version differs from [Han et al. 2020's](https://github.com/hithmh/Actor-critic-with-stability-guarantee/blob/8a90574fae550e98a9b628bbead6da7f91a51fff/ENV/env/mujoco/half_cheetah_cost.py#L23) codebase.